### PR TITLE
README.md typo on `nvm` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Huddly SDK supportes the following node versions:
 - 10.12.0
 - 11.5.0
 
-We recommend using nvm as your node version manager (https://github.com/creationix/nvm).
+We recommend using nvm as your node version manager [https://github.com/creationix/nvm](https://github.com/creationix/nvm).
 
 After you've setup nvm run
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
 <li>10.12.0</li>
 <li>11.5.0</li>
 </ul>
-<p>We recommend using nvm as your node version manager (<a href="https://github.com/creationix/nvm)">https://github.com/creationix/nvm)</a>.</p>
+<p>We recommend using nvm as your node version manager <a href="https://github.com/creationix/nvm">https://github.com/creationix/nvm</a>.</p>
 <p>After you&#39;ve setup nvm run</p>
 <div><pre class="line-numbers"><code class="language-none">  nvm use 8.9.4</code></pre></div><h2 id="get-started">Get started</h2>
 <p>Then you can install and start using the huddly sdk you need first install it and the transport</p>


### PR DESCRIPTION
There was a typo for the link to `nvm` setup. That is all.