### PR TITLE
Camera mode boot bugfix

### DIFF
--- a/src/components/device/boxfish.ts
+++ b/src/components/device/boxfish.ts
@@ -137,8 +137,14 @@ export default class Boxfish extends UvcBaseDevice implements IDeviceManager {
       await this.transport.clear();
       if (mode === 'mvusb') {
         await this.api.sendAndReceiveWithoutLock('upgrader/mv_usb', { args: {} });
+        /**
+         * Do not await reboot as next time the device boots it will
+         * be a movidius device instead of a Huddly IQ device.
+         */
+        this.transport.write('camctrl/reboot');
+      } else {
+        await this.transport.write('camctrl/reboot');
       }
-      await this.transport.write('camctrl/reboot');
     });
   }
 

--- a/src/components/device/boxfish.ts
+++ b/src/components/device/boxfish.ts
@@ -136,12 +136,7 @@ export default class Boxfish extends UvcBaseDevice implements IDeviceManager {
     await this.locksmith.executeAsyncFunction(async () => {
       await this.transport.clear();
       if (mode === 'mvusb') {
-        await this.api.sendAndReceiveWithoutLock('upgrader/mv_usb', { args: {} });
-        /**
-         * Do not await reboot as next time the device boots it will
-         * be a movidius device instead of a Huddly IQ device.
-         */
-        this.transport.write('camctrl/reboot');
+        this.transport.write('upgrader/mv_usb', Api.encode({}));
       } else {
         await this.transport.write('camctrl/reboot');
       }

--- a/tests/components/device/boxfish.spec.ts
+++ b/tests/components/device/boxfish.spec.ts
@@ -118,4 +118,28 @@ describe('Boxfish', () => {
       expect(upgrader.start).to.have.been.calledOnce;
     });
   });
+
+  describe('#reboot', () => {
+    describe('on mvusb mode', () => {
+      it('should send upgrader/mv_usb msg and not await for reboot msg', async () => {
+        await device.initialize();
+        sinon.stub(device.api, 'sendAndReceiveWithoutLock').resolves();
+        await device.reboot('mvusb');
+        expect(device.transport.clear).to.have.been.calledOnce;
+        expect(device.api.sendAndReceiveWithoutLock).to.have.been.calledOnce;
+        expect(device.api.sendAndReceiveWithoutLock).to.have.been.calledWith('upgrader/mv_usb', { args: {}});
+        expect(device.transport.write).to.have.been.calledWith('camctrl/reboot');
+      });
+    });
+    describe('on other modes', () => {
+      it('should only send reboot command', async () => {
+        await device.initialize();
+        sinon.stub(device.api, 'sendAndReceiveWithoutLock').resolves();
+        await device.reboot();
+        expect(device.transport.clear).to.have.been.calledOnce;
+        expect(device.api.sendAndReceiveWithoutLock).to.not.have.been.called;
+        expect(device.transport.write).to.have.been.calledWith('camctrl/reboot');
+      });
+    });
+  });
 });

--- a/tests/components/device/boxfish.spec.ts
+++ b/tests/components/device/boxfish.spec.ts
@@ -10,6 +10,7 @@ import Boxfish from './../../../src/components/device/boxfish';
 import DefaultLogger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import CameraEvents from './../../../src/utilitis/events';
+import Api from './../../../src/components/api';
 
 chai.should();
 chai.use(sinonChai);
@@ -121,23 +122,20 @@ describe('Boxfish', () => {
 
   describe('#reboot', () => {
     describe('on mvusb mode', () => {
-      it('should send upgrader/mv_usb msg and not await for reboot msg', async () => {
+      it('should send upgrader/mv_usb', async () => {
         await device.initialize();
-        sinon.stub(device.api, 'sendAndReceiveWithoutLock').resolves();
         await device.reboot('mvusb');
         expect(device.transport.clear).to.have.been.calledOnce;
-        expect(device.api.sendAndReceiveWithoutLock).to.have.been.calledOnce;
-        expect(device.api.sendAndReceiveWithoutLock).to.have.been.calledWith('upgrader/mv_usb', { args: {}});
-        expect(device.transport.write).to.have.been.calledWith('camctrl/reboot');
+        expect(device.transport.write).to.have.been.calledOnce;
+        expect(device.transport.write).to.have.been.calledWith('upgrader/mv_usb', Api.encode({}));
       });
     });
     describe('on other modes', () => {
       it('should only send reboot command', async () => {
         await device.initialize();
-        sinon.stub(device.api, 'sendAndReceiveWithoutLock').resolves();
         await device.reboot();
         expect(device.transport.clear).to.have.been.calledOnce;
-        expect(device.api.sendAndReceiveWithoutLock).to.not.have.been.called;
+        expect(device.transport.write).to.have.been.calledOnce;
         expect(device.transport.write).to.have.been.calledWith('camctrl/reboot');
       });
     });


### PR DESCRIPTION
When booting the camera into mvusb mode, no reply message is being sent back. That is because after sending `upgrader/mv_usb` message, the camera proceeds to boot and re-enumerate into a custom usb device and any attempt to communicate with the device as Huddly IQ will fail. The fix is to just do a "fire and forget" type of message and then from the caller, check that the device has enumerated on the proper mode.