### PR TITLE
Adding location to getInfo results

### DIFF
--- a/src/components/device/boxfish.ts
+++ b/src/components/device/boxfish.ts
@@ -66,6 +66,7 @@ export default class Boxfish extends UvcBaseDevice implements IDeviceManager {
       vendorId: this['vendorId'],
       productId: this['productId'],
       version: this.extractSemanticSoftwareVersion(info.softwareVersion),
+      location: this['location'],
       ...info
     };
     if (this['pathName'] !== undefined) {


### PR DESCRIPTION
I want to expose the usb location(e.g. 2-1.3.1) given by device-api-usb. To be used in production. 