### PR TITLE
feat(DeviceManager): Get url for latest released firmware for huddly device

### DIFF
--- a/docs/additional-documentation/peoplecount-in-a-meeting-room.html
+++ b/docs/additional-documentation/peoplecount-in-a-meeting-room.html
@@ -202,12 +202,6 @@ init();</code></pre></div><p>Next up we want to create our analytics report</p>
 </ol>
 <h2 id="check-out-your-dashboard">Check out your Dashboard</h2>
 <p>You should now have tracking data coming in, and you can select different date ranges for your report.</p>
-<h2 id="nb-">NB!</h2>
-<h3 id="i-m-not-getting-any-detections-">I&#39;m not getting any detections:</h3>
-<p>  Make sure that you&#39;re streaming from the camera, pick any video application and select HUDDLY IQ, you should start getting in detections.</p>
-<h3 id="detections-without-streaming-on-a-video-applications-">Detections without streaming on a video applications?</h3>
-<p>It is possible to configure the detector in a way that you still get detection events even though you are not occupying the camera stream on the host machine. Please
-have a look at the <code>IDetector</code> interface documentation and the Readme file to find out how this is done!</p>
 
                    </div><div class="search-results">
     <div class="has-results">

--- a/docs/interfaces/IDeviceManager.html
+++ b/docs/interfaces/IDeviceManager.html
@@ -130,6 +130,9 @@
                                     <a href="#getInfo">getInfo</a>
                                 </li>
                                 <li>
+                                    <a href="#getLatestFirmwareUrl">getLatestFirmwareUrl</a>
+                                </li>
+                                <li>
                                     <a href="#getPowerUsage">getPowerUsage</a>
                                 </li>
                                 <li>
@@ -184,7 +187,7 @@
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="68" class="link-to-prism">src/interfaces/iDeviceManager.ts:68</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="69" class="link-to-prism">src/interfaces/iDeviceManager.ts:69</a></div>
                             </td>
                         </tr>
 
@@ -231,7 +234,7 @@ successful connnection close or rejects otherwise.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="96" class="link-to-prism">src/interfaces/iDeviceManager.ts:96</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="97" class="link-to-prism">src/interfaces/iDeviceManager.ts:97</a></div>
                             </td>
                         </tr>
 
@@ -308,7 +311,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="134" class="link-to-prism">src/interfaces/iDeviceManager.ts:134</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="135" class="link-to-prism">src/interfaces/iDeviceManager.ts:135</a></div>
                             </td>
                         </tr>
 
@@ -386,7 +389,7 @@ you to configure the autozoom (genius framing) on the camera.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="145" class="link-to-prism">src/interfaces/iDeviceManager.ts:145</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="146" class="link-to-prism">src/interfaces/iDeviceManager.ts:146</a></div>
                             </td>
                         </tr>
 
@@ -465,7 +468,7 @@ from the camera.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="152" class="link-to-prism">src/interfaces/iDeviceManager.ts:152</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="153" class="link-to-prism">src/interfaces/iDeviceManager.ts:153</a></div>
                             </td>
                         </tr>
 
@@ -511,7 +514,7 @@ from the camera.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="86" class="link-to-prism">src/interfaces/iDeviceManager.ts:86</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="87" class="link-to-prism">src/interfaces/iDeviceManager.ts:87</a></div>
                             </td>
                         </tr>
 
@@ -589,7 +592,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="76" class="link-to-prism">src/interfaces/iDeviceManager.ts:76</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="77" class="link-to-prism">src/interfaces/iDeviceManager.ts:77</a></div>
                             </td>
                         </tr>
 
@@ -617,6 +620,85 @@ in case it takes longer than expected.</p>
             <tbody>
                 <tr>
                     <td class="col-md-4">
+                        <a name="getLatestFirmwareUrl"></a>
+                        <span class="name">
+                            <b>
+                            getLatestFirmwareUrl
+                            </b>
+                            <a href="#getLatestFirmwareUrl"><span class="icon ion-ios-link"></span></a>
+                        </span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+<code>getLatestFirmwareUrl(releaseChannel: <a href="../undefineds/ReleaseChannel.html">ReleaseChannel</a>)</code>
+                    </td>
+                </tr>
+
+
+                        <tr>
+                            <td class="col-md-4">
+                                    <div class="io-line">Defined in <a href="" data-line="188" class="link-to-prism">src/interfaces/iDeviceManager.ts:188</a></div>
+                            </td>
+                        </tr>
+
+
+                <tr>
+                    <td class="col-md-4">
+                            <div class="io-description"><p>Queries the Huddly release server to find out the url
+to the latest firmware release for the specific device
+type (IQ, GO).</p>
+</div>
+
+                            <div class="io-description">
+                                    <b>Parameters :</b>
+                                    <table class="params">
+                                        <thead>
+                                            <tr>
+                                                <td>Name</td>
+                                                    <td>Type</td>
+                                                <td>Optional</td>
+                                                    <td>Description</td>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                                <tr>
+                                                        <td>releaseChannel</td>
+                                                        <td>
+                                                                    <code><a href="../miscellaneous/enumerations.html#ReleaseChannel" target="_self" >ReleaseChannel</a></code>
+                                                        </td>
+                                                    
+                                                    <td>
+                                                            No
+                                                    </td>
+                                                    
+
+                                                        <td>
+                                                                <p>The firmware release
+channel.</p>
+
+                                                        </td>
+                                                </tr>
+                                        </tbody>
+                                    </table>
+                            </div>
+                            <div>
+                            </div>
+                            <div class="io-description">
+                                <b>Returns : </b>    <code><a href="https://www.typescriptlang.org/docs/handbook/basic-types.html" target="_blank" >any</a></code>
+
+                            </div>
+                                <div class="io-description">
+                                    
+                                </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
                         <a name="getPowerUsage"></a>
                         <span class="name">
                             <b>
@@ -635,7 +717,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="168" class="link-to-prism">src/interfaces/iDeviceManager.ts:168</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="169" class="link-to-prism">src/interfaces/iDeviceManager.ts:169</a></div>
                             </td>
                         </tr>
 
@@ -681,7 +763,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="160" class="link-to-prism">src/interfaces/iDeviceManager.ts:160</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="161" class="link-to-prism">src/interfaces/iDeviceManager.ts:161</a></div>
                             </td>
                         </tr>
 
@@ -727,7 +809,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="176" class="link-to-prism">src/interfaces/iDeviceManager.ts:176</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="177" class="link-to-prism">src/interfaces/iDeviceManager.ts:177</a></div>
                             </td>
                         </tr>
 
@@ -773,7 +855,7 @@ in case it takes longer than expected.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="114" class="link-to-prism">src/interfaces/iDeviceManager.ts:114</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="115" class="link-to-prism">src/interfaces/iDeviceManager.ts:115</a></div>
                             </td>
                         </tr>
 
@@ -820,7 +902,7 @@ be used to perform camera upgrades.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="59" class="link-to-prism">src/interfaces/iDeviceManager.ts:59</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="60" class="link-to-prism">src/interfaces/iDeviceManager.ts:60</a></div>
                             </td>
                         </tr>
 
@@ -865,7 +947,7 @@ be used to perform camera upgrades.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="105" class="link-to-prism">src/interfaces/iDeviceManager.ts:105</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="106" class="link-to-prism">src/interfaces/iDeviceManager.ts:106</a></div>
                             </td>
                         </tr>
 
@@ -941,7 +1023,7 @@ be used to perform camera upgrades.</p>
 
                         <tr>
                             <td class="col-md-4">
-                                    <div class="io-line">Defined in <a href="" data-line="124" class="link-to-prism">src/interfaces/iDeviceManager.ts:124</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="125" class="link-to-prism">src/interfaces/iDeviceManager.ts:125</a></div>
                             </td>
                         </tr>
 
@@ -1159,6 +1241,7 @@ import UpgradeOpts from &#x27;./IUpgradeOpts&#x27;;
 import DetectorOpts from &#x27;./IDetectorOpts&#x27;;
 import AutozoomControlOpts from &#x27;./IAutozoomControlOpts&#x27;;
 import { DiagnosticsMessage } from &#x27;../components/diagnosticsMessage&#x27;;
+import ReleaseChannel from &#x27;./ReleaseChannelEnum&#x27;;
 
 /**
  * Interface used for performing actions on the camera.
@@ -1326,6 +1409,17 @@ export default interface IDeviceManager {
    * @memberof IDeviceManager
    */
   getTemperature(): Promise&lt;any&gt;;
+
+  /**
+   * Queries the Huddly release server to find out the url
+   * to the latest firmware release for the specific device
+   * type (IQ, GO).
+   *
+   * @param {ReleaseChannel} releaseChannel The firmware release
+   * channel.
+   * @memberof IDeviceManager
+   */
+  getLatestFirmwareUrl(releaseChannel: ReleaseChannel);
 }
 </code></pre>
     </div>

--- a/docs/miscellaneous/enumerations.html
+++ b/docs/miscellaneous/enumerations.html
@@ -62,6 +62,9 @@
                         <li>
                             <a href="#IMAGE_TYPES" title="src/interfaces/IBoxfishUpgraderFile.ts"><b>IMAGE_TYPES</b>&nbsp;&nbsp;&nbsp;(src/.../IBoxfishUpgraderFile.ts)</a>
                         </li>
+                        <li>
+                            <a href="#ReleaseChannel" title="src/interfaces/ReleaseChannelEnum.ts"><b>ReleaseChannel</b>&nbsp;&nbsp;&nbsp;(src/.../ReleaseChannelEnum.ts)</a>
+                        </li>
                     </ul>
                 </td>
             </tr>
@@ -210,6 +213,39 @@
                         <tr>
                             <td class="col-md-4">
                                 <i>Value : </i><code>bf_app_header_signed</code>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>
+</section>
+    <h3>src/interfaces/ReleaseChannelEnum.ts</h3>
+    <section>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="ReleaseChannel"></a>
+                        <span class="name"><b>ReleaseChannel</b><a href="#ReleaseChannel"><span class="icon ion-ios-link"></span></a></span>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                &nbsp;STABLE
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                <i>Value : </i><code>stable</code>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                &nbsp;RELEASE_CANDIDATE
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="col-md-4">
+                                <i>Value : </i><code>rc</code>
                             </td>
                         </tr>
             </tbody>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,6 +4201,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4926,6 +4932,37 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "nock": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.3.4.tgz",
+      "integrity": "sha512-Mqjk3DeOkuji8eYaveUku+vMswxzVyhrKAz1J9jE86IsEHQg4136Z/PHz81lcjyz9F3yrJXu56Gb/S+LFUOZVg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.0",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "node-environment-flags": {
@@ -5804,6 +5841,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.13.0",
     "mocha": "^6.1.4",
+    "nock": "^11.3.4",
     "nyc": "~14.1.1",
     "pre-commit": "~1.2.2",
     "prettier": "^1.17.1",

--- a/src/components/device/boxfish.ts
+++ b/src/components/device/boxfish.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'events';
+
 import Api from './../api';
 import DefaultLogger from './../../utilitis/logger';
 import UvcBaseDevice from './uvcbase';
@@ -11,13 +13,13 @@ import Locksmith from './../locksmith';
 import CameraEvents from './../../utilitis/events';
 import Detector from './../detector';
 import { MinMaxDiagnosticsMessage, DiagnosticsMessage  } from '../diagnosticsMessage';
-import { EventEmitter } from 'events';
 import { createBoxfishUpgrader } from './../upgrader/boxfishUpgraderFactory';
 import BoxfishUpgrader from './../upgrader/boxfishUpgrader';
 import InterpolationParams from './../../interfaces/InterpolationParams';
 import AutozoomControlOpts from '../../interfaces/IAutozoomControlOpts';
 import IAutozoomControl from '../../interfaces/IAutozoomControl';
 import AutozoomControl from '../autozoomControl';
+import ReleaseChannel from './../../interfaces/ReleaseChannelEnum';
 
 const MAX_UPGRADE_ATTEMPT = 3;
 
@@ -262,5 +264,9 @@ export default class Boxfish extends UvcBaseDevice implements IDeviceManager {
 
   async getInterpolationParams(): Promise<InterpolationParams> {
     return this.api.getInterpolationParameters();
+  }
+
+  async getLatestFirmwareUrl(releaseChannel: ReleaseChannel = ReleaseChannel.STABLE) {
+    return this.api.getLatestFirmwareUrl('iq', releaseChannel);
   }
 }

--- a/src/components/device/huddlygo.ts
+++ b/src/components/device/huddlygo.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'events';
+
 import Api from '../api';
 import DefaultLogger from './../../utilitis/logger';
 import UvcBaseDevice from './uvcbase';
@@ -9,10 +11,10 @@ import UpgradeOpts from './../../interfaces/IUpgradeOpts';
 import InterpolationParams from './../../interfaces/InterpolationParams';
 import Locksmith from './../locksmith';
 import CameraEvents from './../../utilitis/events';
-import { EventEmitter } from 'events';
 import HuddlyGoUpgrader from './../upgrader/huddlygoUpgrader';
 import { DiagnosticsMessage, MinMaxDiagnosticsMessage } from '../diagnosticsMessage';
 import IAutozoomControl from '../../interfaces/IAutozoomControl';
+import ReleaseChannel from './../../interfaces/ReleaseChannelEnum';
 
 const FETCH_UX_CONTROLS_ATTEMPTS = 10;
 
@@ -297,5 +299,9 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
   async getInterpolationParams(): Promise<InterpolationParams> {
     this.logger.warn('Attempting to call method [getInterpolationParams] on HuddlyGO', 'HuddlyGO API');
     throw new Error('Interpolation parameters are not supported on Huddly GO camera');
+  }
+
+  async getLatestFirmwareUrl(releaseChannel: ReleaseChannel = ReleaseChannel.STABLE) {
+    return this.api.getLatestFirmwareUrl('go', releaseChannel);
   }
 }

--- a/src/interfaces/ReleaseChannelEnum.ts
+++ b/src/interfaces/ReleaseChannelEnum.ts
@@ -1,0 +1,6 @@
+enum ReleaseChannel {
+  STABLE = 'stable',
+  RELEASE_CANDIDATE = 'rc',
+}
+
+export default ReleaseChannel;

--- a/src/interfaces/iDeviceManager.ts
+++ b/src/interfaces/iDeviceManager.ts
@@ -7,6 +7,7 @@ import UpgradeOpts from './IUpgradeOpts';
 import DetectorOpts from './IDetectorOpts';
 import AutozoomControlOpts from './IAutozoomControlOpts';
 import { DiagnosticsMessage } from '../components/diagnosticsMessage';
+import ReleaseChannel from './ReleaseChannelEnum';
 
 /**
  * Interface used for performing actions on the camera.
@@ -174,4 +175,15 @@ export default interface IDeviceManager {
    * @memberof IDeviceManager
    */
   getTemperature(): Promise<any>;
+
+  /**
+   * Queries the Huddly release server to find out the url
+   * to the latest firmware release for the specific device
+   * type (IQ, GO).
+   *
+   * @param {ReleaseChannel} releaseChannel The firmware release
+   * channel.
+   * @memberof IDeviceManager
+   */
+  getLatestFirmwareUrl(releaseChannel: ReleaseChannel);
 }

--- a/tests/components/api.spec.ts
+++ b/tests/components/api.spec.ts
@@ -1,12 +1,13 @@
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
+import * as msgpack from 'msgpack-lite';
+import nock from 'nock';
 import Api from './../../src/components/api';
 import Locksmith from './../../src/components/locksmith';
-import * as msgpack from 'msgpack-lite';
 import ITransport from './../../src/interfaces/iTransport';
 import DefaultLogger from './../../src/utilitis/logger';
-
+import ReleaseChannel from './../../src/interfaces/ReleaseChannelEnum';
 
 chai.should();
 chai.use(sinonChai);
@@ -491,6 +492,111 @@ describe('API', () => {
         receive: 'autozoom/status_reply'
       });
       expect(status).to.equals('enabled');
+    });
+  });
+
+  describe('#getLatestFirmwareUrl', () => {
+    describe('on 204 status code', () => {
+      beforeEach(() => {
+        nock('http://huddlyreleaseserver.azurewebsites.net')
+        .get('/releases/stable/latest/iq')
+        .reply(204);
+      });
+      it('should reject with NO_UPDATE_AVAILABLE when response status code is 204', () =>
+        api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE)
+        .should.be.rejectedWith('There are no available firmware packages for this this channel')
+      );
+    });
+    describe('on request error', () => {
+      beforeEach(() => {
+        nock('http://huddlyreleaseserver.azurewebsites.net')
+        .get('/releases/stable/latest/iq')
+        .replyWithError('FAILED');
+      });
+      it('should reject when the response contains error message', async () => {
+        try {
+          await api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE);
+          throw new Error('Request should fail, but it passed!');
+        } catch (e) {
+          expect(e.message).to.be.equal('Request error!\n Error: FAILED');
+        }
+      });
+    });
+
+    describe('on 404 status code', () => {
+      beforeEach(() => {
+        nock('http://huddlyreleaseserver.azurewebsites.net')
+        .get('/releases/stable/latest/iq')
+        .reply(404);
+      });
+      it('should reject with 404', () =>
+        api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE)
+        .should.be.rejectedWith('Failed performing a request to Huddly release server!\nStatus Code: 404')
+      );
+    });
+
+    describe('on non json content type', () => {
+      beforeEach(() => {
+        nock('http://huddlyreleaseserver.azurewebsites.net')
+          .defaultReplyHeaders({
+            'Content-Type': 'application/xml',
+          })
+          .get('/releases/stable/latest/iq')
+          .reply(200);
+      });
+      it('should reject content type error message', () =>
+        api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE)
+          .should.be.rejectedWith('Invalid content-type.\nExpected application/json but received application/xml')
+      );
+    });
+
+    describe('on get IQ firmware url', () => {
+      describe('on empty url_hpk key', () => {
+        beforeEach(() => {
+          nock('http://huddlyreleaseserver.azurewebsites.net')
+          .get('/releases/stable/latest/iq')
+          .reply(200, { version: '1.1.2' });
+        });
+
+        it('should reject when json cant be parsed', async () => {
+          try {
+            await api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE);
+            throw new Error('Request should fail, but it passed!');
+          } catch (e) {
+            expect(e.message).to.be.equal('JSON content does not contain \'url_hpk\' key!');
+          }
+        });
+      });
+
+      describe('on valid json body', () => {
+        beforeEach(() => {
+          nock('http://huddlyreleaseserver.azurewebsites.net')
+          .get('/releases/stable/latest/iq')
+          .reply(200, { url_hpk: 'test', version: '1.1.2' });
+        });
+
+        it('should download the firmware on the given url specified in url_hpk key', async () => {
+          const url = await api.getLatestFirmwareUrl('iq', ReleaseChannel.STABLE);
+          expect(url).to.equals('test');
+        });
+      });
+    });
+
+    describe('on get GO firmware url', () => {
+      beforeEach(() => {
+        nock('http://huddlyreleaseserver.azurewebsites.net')
+          .get('/releases/stable/latest/go')
+          .reply(200, { hpk_url: '123', version: '1.1.2' });
+      });
+
+      it('should reject when json body does not contain "url" key', async () => {
+        try {
+          await api.getLatestFirmwareUrl('go', ReleaseChannel.STABLE);
+          throw new Error('Request should fail, but it passed!');
+        } catch (e) {
+          expect(e.message).to.be.equal('JSON content does not contain \'url\' key!');
+        }
+      });
     });
   });
 });

--- a/tests/components/device/boxfish.spec.ts
+++ b/tests/components/device/boxfish.spec.ts
@@ -11,6 +11,7 @@ import DefaultLogger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import CameraEvents from './../../../src/utilitis/events';
 import Api from './../../../src/components/api';
+import ReleaseChannel from './../../../src/interfaces/ReleaseChannelEnum';
 
 chai.should();
 chai.use(sinonChai);
@@ -138,6 +139,31 @@ describe('Boxfish', () => {
         expect(device.transport.write).to.have.been.calledOnce;
         expect(device.transport.write).to.have.been.calledWith('camctrl/reboot');
       });
+    });
+  });
+
+  describe('#getLatestFirmwareUrl', () => {
+    let getLatestFirmwareUrlStub;
+    beforeEach(async () => {
+      await device.initialize();
+      getLatestFirmwareUrlStub = sinon.stub(device.api, 'getLatestFirmwareUrl').resolves({});
+    });
+    afterEach(() => {
+      getLatestFirmwareUrlStub.restore();
+    });
+
+    it('should call api.getLatestFirmwareUrl', async () => {
+      await device.getLatestFirmwareUrl();
+      expect(getLatestFirmwareUrlStub.called).to.equals(true);
+      expect(getLatestFirmwareUrlStub.getCall(0).args[0]).to.equals('iq');
+      expect(getLatestFirmwareUrlStub.getCall(0).args[1]).to.equals(ReleaseChannel.STABLE);
+    });
+
+    it('should call api.getLatestFirmwareUrl with non-default channel', async () => {
+      await device.getLatestFirmwareUrl(ReleaseChannel.RELEASE_CANDIDATE);
+      expect(getLatestFirmwareUrlStub.called).to.equals(true);
+      expect(getLatestFirmwareUrlStub.getCall(0).args[0]).to.equals('iq');
+      expect(getLatestFirmwareUrlStub.getCall(0).args[1]).to.equals(ReleaseChannel.RELEASE_CANDIDATE);
     });
   });
 });

--- a/tests/mocks/devicemanager.mock.ts
+++ b/tests/mocks/devicemanager.mock.ts
@@ -46,4 +46,5 @@ export default class DeviceManagerMock implements IDeviceManager {
   getState(): Promise<any> { return Promise.resolve(); }
   getPowerUsage(): Promise<any> { return Promise.resolve(); }
   getTemperature(): Promise<any> { return Promise.resolve(); }
+  getLatestFirmwareUrl(): Promise<any> { return Promise.resolve(); }
 }


### PR DESCRIPTION
Use the SDK to find out what is the latest released firmware for any huddly device (GO and IQ for
now). Based on what device is plugged into your machine, calling `getLatestFirmwareUrl` will return
the url to the firmware package for the provided release channel (which by default is the "stable"
channel)