### PR TITLE
refactor(Factory.ts): Remove confusing warning logs on factory class

### DIFF
--- a/src/components/device/factory.ts
+++ b/src/components/device/factory.ts
@@ -74,7 +74,9 @@ export default class DeviceFactory {
       return preferredDeviceApi.getUVCControlAPIForDevice(device);
     }
 
-    logger.warn('Preferred device api does not support uvc control interface', 'SDK DeviceFactory');
+    /**
+     * Main device api does not support uvc control interface
+     */
 
     for (const deviceApi of secondaryDeviceApis) {
       if (await deviceApi.isUVCControlsSupported(device)) {
@@ -82,8 +84,9 @@ export default class DeviceFactory {
       }
     }
 
-    logger.error('None of the device api\'s support uvc control interface', '', 'SDK DeviceFactory');
-
+    /**
+     * None of the device api's support uvc control interface
+     */
     return undefined;
   }
 


### PR DESCRIPTION
Since uvc control interface is not supported on the open source version of the sdk, logging warnings
that none of the device api's do not support uvc control interface is redundant.