### PR TITLE
fix(api.ts): getErrorLog recursive call with exact parameters

### DIFF
--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -439,7 +439,7 @@ export default class Api {
     } catch (e) {
       if (retry > 0) {
         this.logger.debug('Retrying getErrorLog', 'SDK API');
-        return this.getErrorLog(timeout, retry - 1);
+        return this.getErrorLog(timeout, retry - 1, allowLegacy);
       } else if (allowLegacy) {
         this.getErrorLogMsgPackSupport = false;
         this.logger.debug(


### PR DESCRIPTION
When calling getErrorLog recursively after it failed the first time, we need to make sure we are
passing the exact same parameters as the original call (with exception of the retry parameter which of course will be subtracted for each call as it is the termination logic for the recursion).