### PR TITLE
L1 service proto

### DIFF
--- a/huddlyproto/package-lock.json
+++ b/huddlyproto/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@huddly/huddlyproto",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/huddlyproto/package.json
+++ b/huddlyproto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huddly/huddlyproto",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "An npm package describing and bundling all the huddly proto files",
   "keywords": [
     "SDK",

--- a/huddlyproto/proto/win_service.proto
+++ b/huddlyproto/proto/win_service.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+import "google/protobuf/empty.proto";
+package huddly;
+option csharp_namespace = "Huddly.Camera.Service.gRPC";
+
+service HuddlyCameraService
+
+{
+  rpc SetDefaultCamera(CameraInfo) returns (google.protobuf.Empty) {}
+  rpc GetDefaultCamera(google.protobuf.Empty) returns (CameraInfo) {}
+  rpc SetActiveCamera(CameraInfo) returns (google.protobuf.Empty) {}
+  rpc GetActiveCamera(google.protobuf.Empty) returns (CameraInfo) {}
+  rpc SetUserPTZ(UserPtz) returns (google.protobuf.Empty) {}
+  rpc GetUserPTZ(google.protobuf.Empty)returns (UserPtz) {}
+}
+
+message UserPtz
+{
+  bool enabled = 1;
+}
+
+message CameraInfo
+{
+  string mac = 1;
+  string ip = 2;
+  string name = 3;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,14 +542,24 @@
       }
     },
     "@huddly/huddlyproto": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@huddly/huddlyproto/-/huddlyproto-0.0.1.tgz",
-      "integrity": "sha512-nyh35hbUvTr9UPGlEbaj02+C4crxz80o73tzA395mX5YJIbbxPlqYysMfNOzRbR//FBnO/o6layYJAnEYuEN/g==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@huddly/huddlyproto/-/huddlyproto-0.0.3.tgz",
+      "integrity": "sha512-Yb1g2uEtvBeHy6kRUdzhErU4XWJH4ORch+4hiKJLz5N2Fvthm4bTfxJThR60gkXNN8pXhI8oTClLGf82z4dllA==",
       "requires": {
         "@grpc/grpc-js": "^1.3.2",
         "grpc-tools": "^1.11.1",
         "grpc_tools_node_protoc_ts": "^5.2.2",
         "ts-protoc-gen": "^0.15.0"
+      },
+      "dependencies": {
+        "ts-protoc-gen": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.15.0.tgz",
+          "integrity": "sha512-TycnzEyrdVDlATJ3bWFTtra3SCiEP0W0vySXReAuEygXCUr1j2uaVyL0DhzjwuUdQoW5oXPwk6oZWeA0955V+g==",
+          "requires": {
+            "google-protobuf": "^3.15.5"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -6840,14 +6850,6 @@
             "source-map": "^0.6.0"
           }
         }
-      }
-    },
-    "ts-protoc-gen": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.15.0.tgz",
-      "integrity": "sha512-TycnzEyrdVDlATJ3bWFTtra3SCiEP0W0vySXReAuEygXCUr1j2uaVyL0DhzjwuUdQoW5oXPwk6oZWeA0955V+g==",
-      "requires": {
-        "google-protobuf": "^3.15.5"
       }
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.3.2",
-    "@huddly/huddlyproto": "0.0.1",
+    "@huddly/huddlyproto": "0.0.3",
     "cpio-stream": "^1.4.1",
     "google-protobuf": "^3.17.3",
     "jszip": "^3.2.2",

--- a/src/components/service/factory.ts
+++ b/src/components/service/factory.ts
@@ -4,6 +4,13 @@ import IServiceOpts from '../../interfaces/IServiceOpts';
 import IHuddlyService from './../../interfaces/IHuddlyService';
 
 export default class ServiceFactory {
+  /**
+   * Get a concrete IHuddlyService implementation
+   * @param  {ILogger} logger Logger instance
+   * @param  {IServiceOpts} serviceOpts Service options for initializing and seting up the service communication
+   * @returns An intance of IHuddlyService that can be used to communicate with the corresponding
+   * huddly service running on host.
+   */
   static getService(logger: ILogger, serviceOpts: IServiceOpts): IHuddlyService {
     switch (process.platform) {
       case 'win32':

--- a/src/components/service/factory.ts
+++ b/src/components/service/factory.ts
@@ -1,0 +1,17 @@
+import WinIpCameraService from './winIpCameraService';
+import ILogger from './../../interfaces/iLogger';
+import IServiceOpts from '../../interfaces/IServiceOpts';
+import IHuddlyService from './../../interfaces/IHuddlyService';
+
+export default class ServiceFactory {
+  static getService(logger: ILogger, serviceOpts: IServiceOpts): IHuddlyService {
+    switch (process.platform) {
+      case 'win32':
+        return new WinIpCameraService(logger, serviceOpts);
+      default:
+        throw new Error(
+          `Currently there is no Huddly Service support for platform ${process.platform}`
+        );
+    }
+  }
+}

--- a/src/components/service/winIpCameraService.ts
+++ b/src/components/service/winIpCameraService.ts
@@ -1,0 +1,208 @@
+import IHuddlyService from './../../interfaces/IHuddlyService';
+import IServiceOpts from './../../interfaces/IServiceOpts';
+import ILogger from './../../interfaces/iLogger';
+import { CameraInfo } from './../../interfaces/IWinServiceModels';
+
+import * as winservice from '@huddly/huddlyproto/lib/proto/win_service_pb';
+import { HuddlyCameraServiceClient } from '@huddly/huddlyproto/lib/proto/win_service_grpc_pb';
+import * as grpc from '@grpc/grpc-js';
+import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
+
+export enum ServiceCameraActions {
+  ACTIVE = 0,
+  DEFAULT = 1,
+}
+
+export default class WinIpCameraService implements IHuddlyService {
+  options: IServiceOpts;
+  grpcClient: HuddlyCameraServiceClient;
+  logger: ILogger;
+
+  private readonly GRPC_DEFAULT_CONNECT_TIMEOUT: number = 1; // Seconds
+  private readonly GRPC_PORT: number = 30051;
+
+  constructor(logger: ILogger, opts?: IServiceOpts) {
+    this.options = opts;
+    this.logger = logger;
+  }
+
+  init(): Promise<void> {
+    this.logger.debug('Initializing Windows Ip Camera Service!', WinIpCameraService.name);
+    const deadline = new Date();
+    deadline.setSeconds(
+      deadline.getSeconds() + (this.options.connectionDeadline || this.GRPC_DEFAULT_CONNECT_TIMEOUT)
+    );
+    this.grpcClient = new HuddlyCameraServiceClient(
+      `localhost:${this.GRPC_PORT}`,
+      this.options.credentials || grpc.credentials.createInsecure()
+    );
+
+    return new Promise<void>((resolve, reject) =>
+      this.grpcClient.waitForReady(deadline, error => {
+        if (error) {
+          this.logger.error(
+            `Connection failed with GPRC server on ACE!`,
+            error,
+            WinIpCameraService.name
+          );
+          reject(error);
+        } else {
+          this.logger.debug(`Connection established`, WinIpCameraService.name);
+          resolve();
+        }
+      })
+    );
+  }
+
+  formatMacAddress(mac: string): string {
+    if (mac.indexOf(':') == -1 && mac.indexOf('-') == -1) {
+      throw new Error(
+        `Format Error! The folloing mac address is not valid: ${mac}. Use - or : as delimiters`
+      );
+    }
+    if (mac.indexOf(':') > -1) {
+      return mac.split(':').join('-');
+    }
+    return mac;
+  }
+
+  serviceCameraSetter(action: ServiceCameraActions, camInfo: CameraInfo): Promise<void> {
+    const serviceCamInfo: winservice.CameraInfo = new winservice.CameraInfo();
+    serviceCamInfo.setMac(this.formatMacAddress(camInfo.mac));
+    serviceCamInfo.setName(camInfo.name);
+    serviceCamInfo.setIp(camInfo.ip);
+    const setterActionStr: string = Object.keys(ServiceCameraActions).find(
+      key => ServiceCameraActions[key] === action
+    );
+
+    return new Promise((resolve, reject) => {
+      const setterCallback = (err: grpc.ServiceError) => {
+        if (err) {
+          this.logger.error(
+            `Unable to set ${setterActionStr} camera on service. Error: ${err.details}`,
+            err.stack,
+            WinIpCameraService.name
+          );
+          reject(err.details);
+          return;
+        }
+        resolve();
+      };
+
+      switch (action) {
+        case ServiceCameraActions.ACTIVE:
+          this.grpcClient.setActiveCamera(serviceCamInfo, setterCallback);
+          break;
+        case ServiceCameraActions.DEFAULT:
+          this.grpcClient.setDefaultCamera(serviceCamInfo, setterCallback);
+          break;
+        default:
+          throw new Error(`Unknown service camera action: ${setterActionStr}`);
+      }
+    });
+  }
+
+  serviceCameraGetter(action: ServiceCameraActions): Promise<CameraInfo> {
+    const getterActionStr: string = Object.keys(ServiceCameraActions).find(
+      key => ServiceCameraActions[key] === action
+    );
+    return new Promise((resolve, reject) => {
+      const getterCallback = (err: grpc.ServiceError, cameraInfo: winservice.CameraInfo) => {
+        if (err) {
+          this.logger.error(
+            `Unable to get ${getterActionStr} camera from service. Error: ${err.details}`,
+            err.stack,
+            WinIpCameraService.name
+          );
+          reject(err.details);
+          return;
+        }
+        resolve(cameraInfo.toObject());
+      };
+
+      switch (action) {
+        case ServiceCameraActions.ACTIVE:
+          this.grpcClient.getActiveCamera(new Empty(), getterCallback);
+          break;
+        case ServiceCameraActions.DEFAULT:
+          this.grpcClient.getDefaultCamera(new Empty(), getterCallback);
+          break;
+        default:
+          throw new Error(`Unknown service camera action: ${getterActionStr}`);
+      }
+    });
+  }
+
+  setDefaultCamera(camInfo: CameraInfo): Promise<void> {
+    return this.serviceCameraSetter(ServiceCameraActions.DEFAULT, camInfo);
+  }
+
+  getDefaultCamera(): Promise<CameraInfo> {
+    return this.serviceCameraGetter(ServiceCameraActions.DEFAULT);
+  }
+
+  setActiveCamera(camInfo: CameraInfo): Promise<void> {
+    return this.serviceCameraSetter(ServiceCameraActions.ACTIVE, camInfo);
+  }
+
+  getActiveCamera(): Promise<CameraInfo> {
+    return this.serviceCameraGetter(ServiceCameraActions.ACTIVE);
+  }
+
+  setUserPtz(isAllowed: boolean): Promise<void> {
+    const allowed = new winservice.UserPtz();
+    allowed.setEnabled(isAllowed);
+    return new Promise((resolve, reject) => {
+      this.grpcClient.setUserPTZ(allowed, (err: grpc.ServiceError) => {
+        if (err) {
+          this.logger.error(
+            `Unable to set user ptz on service. Error: ${err.details}`,
+            err.stack,
+            WinIpCameraService.name
+          );
+          reject(err.details);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  isUserPtzAllowed(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      this.grpcClient.getUserPTZ(
+        new Empty(),
+        (err: grpc.ServiceError, isAllowed: winservice.UserPtz) => {
+          if (err) {
+            this.logger.error(
+              `Unable to get information whether user ptz is allowed or not on the service. Error: ${err.details}`,
+              err.stack,
+              WinIpCameraService.name
+            );
+            reject(err.details);
+            return;
+          }
+          resolve(isAllowed.getEnabled());
+        }
+      );
+    });
+  }
+
+  // Alias of #setUserPtz
+  allowUserPtz(): Promise<void> {
+    return this.setUserPtz(true);
+  }
+
+  // Alias of #setUserPtz
+  blokUserPtz(): Promise<void> {
+    return this.setUserPtz(false);
+  }
+
+  close(): Promise<void> {
+    if (this.grpcClient) {
+      this.grpcClient.close();
+      this.grpcClient = undefined;
+    }
+    return Promise.resolve();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,6 +333,13 @@ class HuddlySdk extends EventEmitter {
     await this.deviceDiscoveryApi.initialize();
   }
 
+  /**
+   * Get a huddly service implementation class instance with communication channels already established and ready
+   * to start sending and receiving information to/from.
+   * @param {iLogger} [logger] - Logger instance
+   * @param {IServiceOpts} [serviceOpts] - Service options for initializing and setting up the service communication
+   * @returns A the new instance of the huddly service implementation after the setup stage has been completed
+   */
   static async getService(
     logger: iLogger = new DefaultLogger(true),
     serviceOpts: IServiceOpts = {}
@@ -342,6 +349,7 @@ class HuddlySdk extends EventEmitter {
     return service;
   }
 }
+
 export { CameraEvents, Api };
 
 export default HuddlySdk;

--- a/src/interfaces/IHuddlyService.ts
+++ b/src/interfaces/IHuddlyService.ts
@@ -1,0 +1,8 @@
+import IServiceOpts from './IServiceOpts';
+
+export default interface IHuddlyService {
+  options: IServiceOpts;
+
+  init(): Promise<void>;
+  close(): Promise<void>;
+}

--- a/src/interfaces/IHuddlyService.ts
+++ b/src/interfaces/IHuddlyService.ts
@@ -1,8 +1,31 @@
 import IServiceOpts from './IServiceOpts';
 
+/**
+ * Interface used for communicating with a huddly service that facilitates and improves the experiences
+ * with the huddly network cameras.
+ */
 export default interface IHuddlyService {
+  /**
+   * Service options used to initialize and setup up the communication channel with the
+   * huddly service running on host machine
+   *
+   * @type {IServiceOpts}
+   * @memberof IHuddlyService
+   */
   options: IServiceOpts;
 
+  /**
+   * Initialize all communication channels with the huddly service and make sure service api
+   * endpoints are ready to be consumed.
+   * @returns A promise that resolves when the initialization is successful or rejects
+   * otherwise
+   */
   init(): Promise<void>;
+
+  /**
+   * Teardiwn all communication channels with the huddly service.
+   * @returns A promise that resolves when the teardown is successful or rejects
+   * otherwise
+   */
   close(): Promise<void>;
 }

--- a/src/interfaces/IServiceOpts.ts
+++ b/src/interfaces/IServiceOpts.ts
@@ -1,0 +1,4 @@
+export default interface IServiceOpts {
+  connectionDeadline?: number;
+  credentials?: any;
+}

--- a/src/interfaces/IServiceOpts.ts
+++ b/src/interfaces/IServiceOpts.ts
@@ -1,4 +1,22 @@
+/**
+ * Interface describing the options used when setting up a new huddly camera service instance
+ */
 export default interface IServiceOpts {
+  /**
+   * Grpc connection deadline used to specify the maximum allowed time for a grpc connection
+   * to complete. Time unit is given in seconds.
+   *
+   * @type {number}
+   * @memberof IServiceOpts
+   */
   connectionDeadline?: number;
+
+  /**
+   * Grpc channel connection credentials. For secure connection make sure you pass in your credentials
+   * for establishing the connection with the huddly service grpc server.
+   *
+   * @type {any}
+   * @memberof IServiceOpts
+   */
   credentials?: any;
 }

--- a/src/interfaces/IWinServiceModels.ts
+++ b/src/interfaces/IWinServiceModels.ts
@@ -1,0 +1,5 @@
+export interface CameraInfo {
+  mac?: string;
+  name?: string;
+  ip?: string;
+}

--- a/src/interfaces/IWinServiceModels.ts
+++ b/src/interfaces/IWinServiceModels.ts
@@ -1,3 +1,6 @@
+/**
+ * @ignore
+ */
 export interface CameraInfo {
   mac?: string;
   name?: string;

--- a/tests/components/service/factory.spec.ts
+++ b/tests/components/service/factory.spec.ts
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+
+import IHuddlyService from './../../../src/interfaces/IHuddlyService';
+import ServiceFactory from './../../../src/components/service/factory';
+import Logger from './../../../src/utilitis/logger';
+import WinIpCameraService from './../../../src/components/service/winIpCameraService';
+
+chai.should();
+chai.use(sinonChai);
+
+const stubLogger = () => {
+  return sinon.createStubInstance(Logger);
+};
+
+describe('ServiceFactory', () => {
+  let dummyLogger;
+  let platformMock;
+
+  beforeEach(() => {
+    platformMock = sinon.stub(process, 'platform');
+    dummyLogger = stubLogger();
+  });
+
+  afterEach(() => {
+    platformMock.restore();
+  });
+
+  describe('#getService', () => {
+    it('should create new instance of WinIpCameraService when on Windows os', () => {
+      platformMock.value('win32');
+      const service: IHuddlyService = ServiceFactory.getService(dummyLogger, {});
+      expect(service).to.be.instanceof(WinIpCameraService);
+    });
+
+    it('should throw error when running on ubuntu', () => {
+      const platform = 'linux';
+      platformMock.value(platform);
+      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
+    });
+    it('should throw error when running on osx', () => {
+      const platform = 'darwin';
+      platformMock.value(platform);
+      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
+    });
+    it('should throw error when running on other os', () => {
+      const platform = 'helloworld';
+      platformMock.value(platform);
+      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
+    });
+  });
+});

--- a/tests/components/service/winIpCameraService.spec.ts
+++ b/tests/components/service/winIpCameraService.spec.ts
@@ -1,0 +1,281 @@
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+
+import Logger from './../../../src/utilitis/logger';
+import WinIpCameraService, { ServiceCameraActions } from './../../../src/components/service/winIpCameraService';
+import { HuddlyCameraServiceClient } from '@huddly/huddlyproto/lib/proto/win_service_grpc_pb';
+import * as winservice from '@huddly/huddlyproto/lib/proto/win_service_pb';
+import iLogger from './../../../src/interfaces/iLogger';
+
+
+chai.should();
+chai.use(sinonChai);
+
+const stubLogger = () => {
+  return sinon.createStubInstance(Logger);
+};
+
+const createServiceInstance = (dummyLogger: iLogger): WinIpCameraService => {
+  const service = new WinIpCameraService(dummyLogger, {});
+  const grpcClientMock = sinon.createStubInstance(HuddlyCameraServiceClient, {
+    setActiveCamera: sinon.stub(),
+    setDefaultCamera: sinon.stub(),
+    getActiveCamera: sinon.stub(),
+    getDefaultCamera: sinon.stub(),
+    setUserPTZ: sinon.stub(),
+    getUserPTZ: sinon.stub()
+  });
+  service.grpcClient = grpcClientMock;
+  return service;
+};
+
+describe('WinIpCameraService', () => {
+  let service: WinIpCameraService;
+  let dummyLogger;
+
+  beforeEach(() => {
+    dummyLogger = stubLogger();
+    service = createServiceInstance(dummyLogger);
+  });
+
+  describe('#init', () => {
+    let waitForReadyStub;
+    afterEach(() => {
+      waitForReadyStub.restore();
+    });
+
+    it('should connect', () => {
+      waitForReadyStub = sinon
+        .stub(HuddlyCameraServiceClient.prototype, 'waitForReady')
+        .callsFake((deadline, cb) => {
+          cb(undefined);
+        });
+      const p = service.init();
+      return expect(p).to.be.fulfilled;
+    });
+    it('should not connect', () => {
+      waitForReadyStub = sinon
+        .stub(HuddlyCameraServiceClient.prototype, 'waitForReady')
+        .callsFake((deadline, cb) => {
+          cb(Error('Something went wrong'));
+        });
+      const p = service.init();
+      return expect(p).to.eventually.be.rejectedWith('Something went wrong');
+    });
+  });
+
+  describe('#formatMacAddress', () => {
+    it('should format FF:FF:FF to FF-FF-FF', () => {
+      const expected = 'FF-FF-FF';
+      const got = service.formatMacAddress('FF:FF:FF');
+      expect(expected).to.equal(got);
+    });
+    it('should keep same mac address format is format is correct', () => {
+      const expected = 'FF-FF-FF';
+      const got = service.formatMacAddress(expected);
+      expect(expected).to.equal(got);
+    });
+    it('should throw error when mac address has wrong format', () => {
+      const fn = (macAddr) => { service.formatMacAddress(macAddr); };
+      const malFormedMacs = ['FF,FF,FF,FF', 'FF/FF/FF/FF', '', 'FFFFFFFF'];
+      malFormedMacs.forEach((macAddr) => {
+        expect(() => fn(macAddr)).to.throw(`Format Error! The folloing mac address is not valid: ${macAddr}. Use - or : as delimiters`);
+      });
+    });
+  });
+
+  describe('#serviceCameraSetter', () => {
+    describe('onGrpcSuccess', () => {
+      it('should call setActiveCamera and resolve on callback', () => {
+        (service.grpcClient.setActiveCamera as any).yields(undefined);
+        const promise = service.serviceCameraSetter(ServiceCameraActions.ACTIVE, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        return expect(promise).to.be.fulfilled;
+      });
+      it('should call setDefaultCamera and resolve on callback', () => {
+        (service.grpcClient.setDefaultCamera as any).yields(undefined);
+        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        return expect(promise).to.be.fulfilled;
+      });
+    });
+    describe('onGrpcFailure', () => {
+      it('should reject with the error received from grpc call', () => {
+        (service.grpcClient.setDefaultCamera as any).yields({details: 'Something went wrong', stack: ''});
+        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        return expect(promise).to.eventually.be.rejectedWith('Something went wrong');
+      });
+    });
+    it('should throw error when passing wrong action', () => {
+      const promise = service.serviceCameraSetter(-1, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+      return expect(promise).to.eventually.be.rejectedWith('Unknown service camera action: undefined');
+    });
+  });
+
+  describe('#serviceCameraGetter', () => {
+    const serviceCamInfo: winservice.CameraInfo = new winservice.CameraInfo();
+    before(() => {
+      serviceCamInfo.setMac('FFFFFFF');
+      serviceCamInfo.setName('L1');
+      serviceCamInfo.setIp('1.2.3');
+    });
+
+    describe('onGrpcSuccess', () => {
+      it('should call getActiveCamera and resolve on callback', () => {
+        (service.grpcClient.getActiveCamera as any).yields(undefined, serviceCamInfo);
+        const promise = service.serviceCameraGetter(ServiceCameraActions.ACTIVE);
+        return expect(promise).to.be.fulfilled.then((gotCamInfo) => {
+          expect(gotCamInfo).to.deep.equal(serviceCamInfo.toObject());
+        });
+      });
+      it('should call getDefaultCamera and resolve on callback', () => {
+        (service.grpcClient.getDefaultCamera as any).yields(undefined, serviceCamInfo);
+        const promise = service.serviceCameraGetter(ServiceCameraActions.DEFAULT);
+        return expect(promise).to.be.fulfilled.then((gotCamInfo) => {
+          expect(gotCamInfo).to.deep.equal(serviceCamInfo.toObject());
+        });
+      });
+    });
+    describe('onGrpcFailure', () => {
+      it('should reject with the error received from grpc call', () => {
+        (service.grpcClient.getDefaultCamera as any).yields({details: 'Something went wrong', stack: ''}, undefined);
+        const promise = service.serviceCameraGetter(ServiceCameraActions.DEFAULT);
+        return expect(promise).to.eventually.be.rejectedWith('Something went wrong');
+      });
+    });
+    it('should throw error when passing wrong action', () => {
+      const promise = service.serviceCameraGetter(-1);
+      return expect(promise).to.eventually.be.rejectedWith('Unknown service camera action: undefined');
+    });
+  });
+
+  describe('set/get default/active camera', () => {
+    let serviceCameraSetterStub;
+    let serviceCameraGetterStub;
+    beforeEach(() => {
+      serviceCameraSetterStub = sinon.stub(service, 'serviceCameraSetter').resolves();
+      serviceCameraGetterStub = sinon.stub(service, 'serviceCameraGetter').resolves();
+    });
+    afterEach(() => {
+      serviceCameraSetterStub.restore();
+      serviceCameraGetterStub.restore();
+    });
+    describe('#setDefaultCamera', () => {
+      it('should call serviceCameraSetter with action DEFAULT', () => {
+        service.setDefaultCamera({});
+        expect(serviceCameraSetterStub.called).to.equal(true);
+        expect(serviceCameraSetterStub.getCall(0).args[0]).to.equals(ServiceCameraActions.DEFAULT);
+      });
+    });
+    describe('#getDefaultCamera', () => {
+      it('should call serviceCameraGetter with action DEFAULT', () => {
+        service.getDefaultCamera();
+        expect(serviceCameraGetterStub.called).to.equal(true);
+        expect(serviceCameraGetterStub.getCall(0).args[0]).to.equals(ServiceCameraActions.DEFAULT);
+      });
+    });
+    describe('#setActiveCamera', () => {
+      it('should call serviceCameraSetter with action ACTIVE', () => {
+        service.setActiveCamera({});
+        expect(serviceCameraSetterStub.called).to.equal(true);
+        expect(serviceCameraSetterStub.getCall(0).args[0]).to.equals(ServiceCameraActions.ACTIVE);
+      });
+    });
+    describe('#getActiveCamera', () => {
+      it('should call serviceCameraSetter with action ACTIVE', () => {
+        service.getActiveCamera();
+        expect(serviceCameraGetterStub.called).to.equal(true);
+        expect(serviceCameraGetterStub.getCall(0).args[0]).to.equals(ServiceCameraActions.ACTIVE);
+      });
+    });
+  });
+
+  describe('#setUserPtz', () => {
+    it('should call setUserPtz and resolve on callback', () => {
+      (service.grpcClient.setUserPTZ as any).yields(undefined);
+      const promise = service.setUserPtz(true);
+      return expect(promise).to.be.fulfilled;
+    });
+    it('should reject with the error received from grpc call', () => {
+      (service.grpcClient.setUserPTZ as any).yields({details: 'Something went wrong', stack: ''});
+      const promise = service.setUserPtz(true);
+      return expect(promise).to.eventually.be.rejectedWith('Something went wrong');
+    });
+  });
+
+  describe('#isUserPtzAllowed', () => {
+    it('should allow user ptz', () => {
+      const userPtz: winservice.UserPtz = new winservice.UserPtz();
+      userPtz.setEnabled(true);
+
+      (service.grpcClient.getUserPTZ as any).yields(undefined, userPtz);
+      const promise = service.isUserPtzAllowed();
+      return expect(promise).to.be.fulfilled.then((isAllowed) => {
+        expect(isAllowed).to.equal(true);
+      });
+    });
+    it('should not allow user ptz', () => {
+      const userPtz: winservice.UserPtz = new winservice.UserPtz();
+      userPtz.setEnabled(false);
+
+      (service.grpcClient.getUserPTZ as any).yields(undefined, userPtz);
+      const promise = service.isUserPtzAllowed();
+      return expect(promise).to.be.fulfilled.then((isAllowed) => {
+        expect(isAllowed).to.equal(false);
+      });
+    });
+    it('should reject with the error received from grpc call', () => {
+      (service.grpcClient.getUserPTZ as any).yields({details: 'Something went wrong', stack: ''}, undefined);
+      const promise = service.isUserPtzAllowed();
+      return expect(promise).to.eventually.be.rejectedWith('Something went wrong');
+    });
+  });
+
+  describe('allow/block user ptz', () => {
+    let setUserPtzStub;
+    beforeEach(() => {
+      setUserPtzStub = sinon.stub(service, 'setUserPtz').resolves();
+    });
+    afterEach(() => {
+      setUserPtzStub.restore();
+    });
+    describe('#allowUserPtz', () => {
+      it('should call setUserPtz', () => {
+        service.allowUserPtz();
+        expect(setUserPtzStub.called).to.equal(true);
+        expect(setUserPtzStub.getCall(0).args[0]).to.equals(true);
+      });
+    });
+    describe('#blokUserPtz', () => {
+      it('should call setUserPtz', () => {
+        service.blokUserPtz();
+        expect(setUserPtzStub.called).to.equal(true);
+        expect(setUserPtzStub.getCall(0).args[0]).to.equals(false);
+      });
+    });
+  });
+
+  describe('#close', () => {
+    let waitForReadyStub;
+    let closeSpy;
+    afterEach(() => {
+      waitForReadyStub.restore();
+      closeSpy.restore();
+    });
+    it('should close grpc client if initialized', async () => {
+      closeSpy = sinon.spy(HuddlyCameraServiceClient.prototype, 'close');
+      waitForReadyStub = sinon
+          .stub(HuddlyCameraServiceClient.prototype, 'waitForReady')
+          .callsFake((deadline, cb) => {
+              cb(undefined);
+          });
+      await service.init();
+      await service.close();
+      expect(closeSpy.calledOnce).to.equals(true);
+    });
+    it('should not close when client is not initialized', async () => {
+      closeSpy = sinon.spy(HuddlyCameraServiceClient.prototype, 'close');
+      await service.close();
+      expect(closeSpy.called).to.equals(false);
+    });
+  });
+});

--- a/tests/sdk.spec.ts
+++ b/tests/sdk.spec.ts
@@ -10,6 +10,7 @@ import IUVCControlAPI from '../src/interfaces/iUVCControlApi';
 import ITransport from '../src/interfaces/iTransport';
 import IDeviceDiscovery from '../src/interfaces/iDeviceDiscovery';
 import DeviceFactory from '../src/components/device/factory';
+import ServiceFactory from '../src/components/service/factory';
 
 chai.should();
 chai.use(sinonChai);
@@ -227,6 +228,25 @@ describe('HuddlySDK', () => {
       const sdk = new HuddlySdk(nodeusbDeviceApi, [nodeusbDeviceApi], {});
       await sdk.init();
       expect(nodeusbDeviceApi.initialize.callCount).to.equals(1);
+    });
+  });
+
+  describe('#getService', () => {
+    let serviceFactoryMock;
+    const serviceStub = {
+      init: sinon.stub(),
+    };
+    beforeEach(() => {
+      serviceFactoryMock = sinon.stub(ServiceFactory, 'getService').returns(serviceStub);
+    });
+    afterEach(() => {
+      serviceFactoryMock.restore();
+    });
+    it('should use service factory to create and initialize a huddly service supported for curent os', async () => {
+      serviceStub.init.resolves();
+      const myService = await HuddlySdk.getService();
+      expect(myService).to.deep.equal(serviceStub);
+      expect(serviceStub.init.called).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
- Import service proto file (currently a temporary solution as this should move to falcon-interface)
- Bumped and released new version of @huddly/huddlyproto
- Implemented all the Huddly Windows Service features described on the protofile through SDK api calls
- Boilerplate code for describing Huddly services
- Unit Testing of the new functionality