### PR TITLE
Sdk Logger refactoring

### DIFF
--- a/src/components/autozoomControl.ts
+++ b/src/components/autozoomControl.ts
@@ -2,15 +2,14 @@ import IAutozoomControl from '../interfaces/IAutozoomControl';
 import AutozoomControlOpts from '../interfaces/IAutozoomControlOpts';
 import IDeviceManager from '../interfaces/iDeviceManager';
 import Api from './api';
+import Logger from './../utilitis/logger';
 
 export default class AutozoomControl implements IAutozoomControl {
   _deviceManager: IDeviceManager;
-  _logger: any;
   _options: AutozoomControlOpts;
 
-  constructor(manager: IDeviceManager, logger: any, options?: AutozoomControlOpts) {
+  constructor(manager: IDeviceManager, options?: AutozoomControlOpts) {
     this._deviceManager = manager;
-    this._logger = logger;
     this._options = options || {
       shouldAutoFrame: true,
     };
@@ -23,7 +22,7 @@ export default class AutozoomControl implements IAutozoomControl {
    */
   async init(): Promise<any> {
     if (this._options.shouldAutoFrame !== undefined && this._options.shouldAutoFrame !== null) {
-      this._logger.debug(
+      Logger.debug(
         `Initializing autozoom with framing config option AUTO_PTZ: ${this._options.shouldAutoFrame}`,
         'Autozoom Control'
       );
@@ -52,7 +51,7 @@ export default class AutozoomControl implements IAutozoomControl {
    * @memberof AutozoomControl
    */
   async enable(idleTimeMs: number = 2000): Promise<void> {
-    this._logger.debug('Enabling autozoom persistently', 'Autozoom Control');
+    Logger.debug('Enabling autozoom persistently', 'Autozoom Control');
 
     await this._deviceManager.api.sendAndReceive(
       Buffer.alloc(0),
@@ -85,7 +84,7 @@ export default class AutozoomControl implements IAutozoomControl {
     });
 
     await promise;
-    this._logger.debug('Autozoom enabled persistently', 'Autozoom Control');
+    Logger.debug('Autozoom enabled persistently', 'Autozoom Control');
   }
 
   /**
@@ -94,7 +93,7 @@ export default class AutozoomControl implements IAutozoomControl {
    * @memberof AutozoomControl
    */
   async disable(idleTimeMs: number = 2000): Promise<void> {
-    this._logger.debug('Disabling autozoom persistently', 'Autozoom Control');
+    Logger.debug('Disabling autozoom persistently', 'Autozoom Control');
 
     await this._deviceManager.api.sendAndReceive(
       Buffer.alloc(0),
@@ -127,7 +126,7 @@ export default class AutozoomControl implements IAutozoomControl {
     });
 
     await promise;
-    this._logger.debug('Autozoom disabled persistently', 'Autozoom Control');
+    Logger.debug('Autozoom disabled persistently', 'Autozoom Control');
   }
 
   /**
@@ -148,7 +147,7 @@ export default class AutozoomControl implements IAutozoomControl {
   async start(): Promise<void> {
     if (!(await this.isRunning())) {
       // Only start if not already started
-      this._logger.debug('Starting Autozoom', 'Autozoom Control');
+      Logger.debug('Starting Autozoom', 'Autozoom Control');
       await this._deviceManager.api.sendAndReceive(
         Buffer.alloc(0),
         {
@@ -168,7 +167,7 @@ export default class AutozoomControl implements IAutozoomControl {
   async stop(): Promise<void> {
     if (await this.isRunning()) {
       // Only stop if az is running
-      this._logger.debug('Stopping Autozoom', 'Autozoom Control');
+      Logger.debug('Stopping Autozoom', 'Autozoom Control');
       await this._deviceManager.api.sendAndReceive(
         Buffer.alloc(0),
         {
@@ -201,7 +200,7 @@ export default class AutozoomControl implements IAutozoomControl {
   async uploadBlob(blobBuffer: Buffer): Promise<void> {
     const status = await this._deviceManager.api.getAutozoomStatus();
     if (!status['network-configured']) {
-      this._logger.debug('Uploading cnn blob', 'Autozoom Control');
+      Logger.debug('Uploading cnn blob', 'Autozoom Control');
       await this._deviceManager.api.sendAndReceive(
         blobBuffer,
         {
@@ -210,9 +209,9 @@ export default class AutozoomControl implements IAutozoomControl {
         },
         60000
       );
-      this._logger.debug('Cnn blob has been uploaded. Unlocking the stream!', 'Autozoom Control');
+      Logger.debug('Cnn blob has been uploaded. Unlocking the stream!', 'Autozoom Control');
     } else {
-      this._logger.debug('Cnn blob already configured on the camera', 'Autozoom Control');
+      Logger.debug('Cnn blob already configured on the camera', 'Autozoom Control');
     }
   }
 
@@ -225,7 +224,7 @@ export default class AutozoomControl implements IAutozoomControl {
    * @memberof AutozoomControl
    */
   async setDetectorConfig(config: JSON): Promise<void> {
-    this._logger.debug('Sending detector config!', 'Autozoom Control');
+    Logger.debug('Sending detector config!', 'Autozoom Control');
     await this._deviceManager.api.sendAndReceive(
       Api.encode(config),
       {
@@ -234,7 +233,7 @@ export default class AutozoomControl implements IAutozoomControl {
       },
       6000
     );
-    this._logger.debug('Detector config sent!', 'Autozoom Control');
+    Logger.debug('Detector config sent!', 'Autozoom Control');
   }
 
   /**
@@ -247,7 +246,7 @@ export default class AutozoomControl implements IAutozoomControl {
    * @memberof AutozoomControl
    */
   async uploadFramingConfig(config: any): Promise<void> {
-    this._logger.debug('Uploading new framing config', 'Autozoom Control');
+    Logger.debug('Uploading new framing config', 'Autozoom Control');
     await this._deviceManager.api.sendAndReceive(
       Api.encode(config),
       {
@@ -256,6 +255,6 @@ export default class AutozoomControl implements IAutozoomControl {
       },
       60000
     );
-    this._logger.debug('New framing config uploaded on the camera.', 'Autozoom Control');
+    Logger.debug('New framing config uploaded on the camera.', 'Autozoom Control');
   }
 }

--- a/src/components/device/clownfish.ts
+++ b/src/components/device/clownfish.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events';
 
 import Api from './../api';
-import DefaultLogger from './../../utilitis/logger';
 import Locksmith from './../locksmith';
 import Boxfish from './boxfish';
 import IUsbTransport from './../../interfaces/IUsbTransport';
@@ -10,7 +9,6 @@ export default class ClownFish extends Boxfish {
   transport: IUsbTransport;
   _api: Api;
   uvcControlInterface: any;
-  logger: DefaultLogger;
   locksmith: Locksmith;
   discoveryEmitter: EventEmitter;
   productName: string = 'Huddly IQ';
@@ -19,8 +17,7 @@ export default class ClownFish extends Boxfish {
     uvcCameraInstance: any,
     transport: IUsbTransport,
     uvcControlInterface: any,
-    logger: DefaultLogger,
     cameraDiscoveryEmitter: EventEmitter) {
-    super(uvcCameraInstance, transport, uvcControlInterface, logger, cameraDiscoveryEmitter);
+    super(uvcCameraInstance, transport, uvcControlInterface, cameraDiscoveryEmitter);
   }
 }

--- a/src/components/device/dartfish.ts
+++ b/src/components/device/dartfish.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events';
 
 import Api from './../api';
-import DefaultLogger from './../../utilitis/logger';
 import Locksmith from './../locksmith';
 import Boxfish from './boxfish';
 import IDetector from '../../interfaces/IDetector';
@@ -14,7 +13,6 @@ export default class DartFish extends Boxfish {
   transport: IUsbTransport;
   _api: Api;
   uvcControlInterface: any;
-  logger: DefaultLogger;
   locksmith: Locksmith;
   discoveryEmitter: EventEmitter;
   productName: string = 'Huddly Canvas';
@@ -23,9 +21,8 @@ export default class DartFish extends Boxfish {
     uvcCameraInstance: any,
     transport: IUsbTransport,
     uvcControlInterface: any,
-    logger: DefaultLogger,
     cameraDiscoveryEmitter: EventEmitter) {
-    super(uvcCameraInstance, transport, uvcControlInterface, logger, cameraDiscoveryEmitter);
+    super(uvcCameraInstance, transport, uvcControlInterface, cameraDiscoveryEmitter);
   }
 
   async ensureAppMode() {

--- a/src/components/device/dwarffish.ts
+++ b/src/components/device/dwarffish.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events';
 
 import Api from '../api';
-import DefaultLogger from '../../utilitis/logger';
 import IUsbTransport from '../../interfaces/IUsbTransport';
 import Locksmith from '../locksmith';
 import Boxfish from './boxfish';
@@ -16,7 +15,6 @@ export default class Dwarffish extends Boxfish {
   transport: IUsbTransport;
   _api: Api;
   uvcControlInterface: any;
-  logger: DefaultLogger;
   locksmith: Locksmith;
   discoveryEmitter: EventEmitter;
   productName: string = 'Huddly IQ Lite';
@@ -25,9 +23,8 @@ export default class Dwarffish extends Boxfish {
     uvcCameraInstance: any,
     transport: IUsbTransport,
     uvcControlInterface: any,
-    logger: DefaultLogger,
     cameraDiscoveryEmitter: EventEmitter) {
-    super(uvcCameraInstance, transport, uvcControlInterface, logger, cameraDiscoveryEmitter);
+    super(uvcCameraInstance, transport, uvcControlInterface, cameraDiscoveryEmitter);
   }
 
   async ensureAppMode() {

--- a/src/components/device/huddlygo.ts
+++ b/src/components/device/huddlygo.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import Api from '../api';
-import DefaultLogger from './../../utilitis/logger';
+import Logger from './../../utilitis/logger';
 import UvcBaseDevice from './uvcbase';
 import IUsbTransport from './../../interfaces/IUsbTransport';
 import IDeviceManager from './../../interfaces/iDeviceManager';
@@ -40,7 +40,6 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
   api: Api;
   uvcControlInterface: any;
   hidApi: any;
-  logger: DefaultLogger;
   locksmith: Locksmith;
   softwareVersion: any;
   discoveryEmitter: EventEmitter;
@@ -50,20 +49,18 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
     transport: IUsbTransport,
     uvcControlInterface: any,
     hidAPI: any,
-    logger: DefaultLogger,
     cameraDiscoveryEmitter: EventEmitter) {
     super(uvcCameraInstance, uvcControlInterface);
 
     this.transport = transport;
     this.uvcControlInterface = uvcControlInterface;
     this.hidApi = hidAPI;
-    this.logger = logger;
     this.locksmith = new Locksmith();
     this.discoveryEmitter = cameraDiscoveryEmitter;
   }
 
   async initialize(): Promise<void> {
-    this.api = new Api(this.transport, this.logger, this.locksmith);
+    this.api = new Api(this.transport, this.locksmith);
     this.softwareVersion = await this.getSoftwareVersion();
   }
 
@@ -82,13 +79,13 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
         return softwareVersion;
       } catch (e) {
         err = e;
-        this.logger.error(
+        Logger.error(
           `Failed parsing/reading the software version on GO! Retry Attempts left: ${fetchAttemts - retryAttempts}`,
           e,
           'HuddlyGO API');
       }
     } while (fetchAttemts < retryAttempts);
-    this.logger.error('Unable to retrieve software version from camera!', err, 'HuddlyGO API');
+    Logger.error('Unable to retrieve software version from camera!', err, 'HuddlyGO API');
     throw new Error('Failed to retrieve software version from camera');
   }
 
@@ -262,7 +259,7 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
   }
 
   async getUpgrader(): Promise<IDeviceUpgrader> {
-    return new HuddlyGoUpgrader(this, this.discoveryEmitter, this.hidApi, this.logger);
+    return new HuddlyGoUpgrader(this, this.discoveryEmitter, this.hidApi);
   }
 
   async upgrade(opts: UpgradeOpts): Promise<any> {
@@ -274,43 +271,43 @@ export default class HuddlyGo extends UvcBaseDevice implements IDeviceManager {
         resolve();
       });
       upgrader.once(CameraEvents.UPGRADE_FAILED, (reason) => {
-        this.logger.error('Upgrade Failed', reason, 'HuddlyGO API');
+        Logger.error('Upgrade Failed', reason, 'HuddlyGO API');
         reject(reason);
       });
       upgrader.once(CameraEvents.TIMEOUT, (reason) => {
-        this.logger.error('Upgrader returned a timeout event', reason, 'HuddlyGO API');
+        Logger.error('Upgrader returned a timeout event', reason, 'HuddlyGO API');
         reject(reason);
       });
     });
   }
 
   getAutozoomControl(): IAutozoomControl {
-    this.logger.warn('Attempting to call method [getAutozoomControl] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [getAutozoomControl] on HuddlyGO', 'HuddlyGO API');
     throw new Error('Autozoom is not supported on Huddly GO cameras!');
   }
 
   getFaceBasedExposureControl(): ICnnControl {
-    this.logger.warn('Attempting to call method [getFaceBasedExposureControl] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [getFaceBasedExposureControl] on HuddlyGO', 'HuddlyGO API');
     throw new Error('FaceBased  is not supported on Huddly GO cameras!');
   }
 
   getDetector(): IDetector {
-    this.logger.warn('Attempting to call method [getDetector] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [getDetector] on HuddlyGO', 'HuddlyGO API');
     throw new Error('Detections are not supported on Huddly GO camera!');
   }
 
   getState(): Promise<any> {
-    this.logger.warn('Attempting to call method [getState] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [getState] on HuddlyGO', 'HuddlyGO API');
     throw new Error('State is not supported on Huddly GO camera');
   }
 
   async setInterpolationParams(params: InterpolationParams): Promise<any> {
-    this.logger.warn('Attempting to call method [setInterpolationParams] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [setInterpolationParams] on HuddlyGO', 'HuddlyGO API');
     throw new Error('Interpolation parameters are not supported on Huddly GO camera');
   }
 
   async getInterpolationParams(): Promise<InterpolationParams> {
-    this.logger.warn('Attempting to call method [getInterpolationParams] on HuddlyGO', 'HuddlyGO API');
+    Logger.warn('Attempting to call method [getInterpolationParams] on HuddlyGO', 'HuddlyGO API');
     throw new Error('Interpolation parameters are not supported on Huddly GO camera');
   }
 

--- a/src/components/faceBasedExposureControl.ts
+++ b/src/components/faceBasedExposureControl.ts
@@ -1,13 +1,12 @@
 import ICnnControl from '../interfaces/ICnnControl';
 import IDeviceManager from '../interfaces/iDeviceManager';
+import Logger from './../utilitis/logger';
 
 export default class FaseBasedExposureControl implements ICnnControl {
   _deviceManager: IDeviceManager;
-  _logger: any;
 
-  constructor(manager: IDeviceManager, logger: any) {
+  constructor(manager: IDeviceManager) {
     this._deviceManager = manager;
-    this._logger = logger;
   }
 
   /**
@@ -20,7 +19,7 @@ export default class FaseBasedExposureControl implements ICnnControl {
       const r = await this._deviceManager.api.transport.write('face-based-exposure/enable');
       return r;
     } catch (e) {
-      this._logger.error('Could enable face based exposure', e.message);
+      Logger.error('Could enable face based exposure', e.message);
       throw new Error('Could not enable face based exposure');
     }
   }
@@ -35,7 +34,7 @@ export default class FaseBasedExposureControl implements ICnnControl {
       const r = await this._deviceManager.api.transport.write('face-based-exposure/disable');
       return r;
     } catch (e) {
-      this._logger.error('Could disable face based exposure', e.message);
+      Logger.error('Could disable face based exposure', e.message);
       throw new Error('Could not disable face based exposure');
     }
   }
@@ -57,7 +56,7 @@ export default class FaseBasedExposureControl implements ICnnControl {
       );
       return message['fbe-enabled'];
     } catch (e) {
-      this._logger.error('Could disable face based exposure', e.message);
+      Logger.error('Could disable face based exposure', e.message);
       throw new Error('Could not get face based exposure status');
     }
   }

--- a/src/components/service/factory.ts
+++ b/src/components/service/factory.ts
@@ -1,20 +1,18 @@
 import WinIpCameraService from './winIpCameraService';
-import ILogger from './../../interfaces/iLogger';
 import IServiceOpts from '../../interfaces/IServiceOpts';
 import IHuddlyService from './../../interfaces/IHuddlyService';
 
 export default class ServiceFactory {
   /**
    * Get a concrete IHuddlyService implementation
-   * @param  {ILogger} logger Logger instance
    * @param  {IServiceOpts} serviceOpts Service options for initializing and seting up the service communication
    * @returns An intance of IHuddlyService that can be used to communicate with the corresponding
    * huddly service running on host.
    */
-  static getService(logger: ILogger, serviceOpts: IServiceOpts): IHuddlyService {
+  static getService(serviceOpts: IServiceOpts): IHuddlyService {
     switch (process.platform) {
       case 'win32':
-        return new WinIpCameraService(logger, serviceOpts);
+        return new WinIpCameraService(serviceOpts);
       default:
         throw new Error(
           `Currently there is no Huddly Service support for platform ${process.platform}`

--- a/src/components/service/winIpCameraService.ts
+++ b/src/components/service/winIpCameraService.ts
@@ -1,7 +1,7 @@
 import IHuddlyService from './../../interfaces/IHuddlyService';
 import IServiceOpts from './../../interfaces/IServiceOpts';
-import ILogger from './../../interfaces/iLogger';
 import { CameraInfo } from './../../interfaces/IWinServiceModels';
+import Logger from './../../../src/utilitis/logger';
 
 import * as winservice from '@huddly/huddlyproto/lib/proto/win_service_pb';
 import { HuddlyCameraServiceClient } from '@huddly/huddlyproto/lib/proto/win_service_grpc_pb';
@@ -37,13 +37,6 @@ export default class WinIpCameraService implements IHuddlyService {
   grpcClient: HuddlyCameraServiceClient;
 
   /**
-   * Logger instance for logging useful information, logs and traces
-   * @type {ILogger}
-   * @memberof WinIpCameraService
-   */
-  logger: ILogger;
-
-  /**
    * @ignore
    * @type {number}
    * @memberof WinIpCameraService
@@ -59,12 +52,10 @@ export default class WinIpCameraService implements IHuddlyService {
 
   /**
    * Creates a new instance of WinUpCameraService and initializes the necessary class attributes
-   * @param  {ILogger} logger Logger instance for logging information
    * @param  {IServiceOpts} opts? Service options for initializing and setting up the service communication
    */
-  constructor(logger: ILogger, opts?: IServiceOpts) {
+  constructor(opts?: IServiceOpts) {
     this.options = opts;
-    this.logger = logger;
   }
 
   /**
@@ -73,7 +64,7 @@ export default class WinIpCameraService implements IHuddlyService {
    * or rejects if not.
    */
   init(): Promise<void> {
-    this.logger.debug('Initializing Windows Ip Camera Service!', WinIpCameraService.name);
+    Logger.debug('Initializing Windows Ip Camera Service!', WinIpCameraService.name);
     const deadline = new Date();
     deadline.setSeconds(
       deadline.getSeconds() + (this.options.connectionDeadline || this.GRPC_DEFAULT_CONNECT_TIMEOUT)
@@ -86,14 +77,14 @@ export default class WinIpCameraService implements IHuddlyService {
     return new Promise<void>((resolve, reject) =>
       this.grpcClient.waitForReady(deadline, error => {
         if (error) {
-          this.logger.error(
+          Logger.error(
             `Connection failed with GPRC server on ACE!`,
             error,
             WinIpCameraService.name
           );
           reject(error);
         } else {
-          this.logger.debug(`Connection established`, WinIpCameraService.name);
+          Logger.debug(`Connection established`, WinIpCameraService.name);
           resolve();
         }
       })
@@ -141,7 +132,7 @@ export default class WinIpCameraService implements IHuddlyService {
     return new Promise((resolve, reject) => {
       const setterCallback = (err: grpc.ServiceError) => {
         if (err) {
-          this.logger.error(
+          Logger.error(
             `Unable to set ${setterActionStr} camera on service. Error: ${err.details}`,
             err.stack,
             WinIpCameraService.name
@@ -180,7 +171,7 @@ export default class WinIpCameraService implements IHuddlyService {
     return new Promise((resolve, reject) => {
       const getterCallback = (err: grpc.ServiceError, cameraInfo: winservice.CameraInfo) => {
         if (err) {
-          this.logger.error(
+          Logger.error(
             `Unable to get ${getterActionStr} camera from service. Error: ${err.details}`,
             err.stack,
             WinIpCameraService.name
@@ -259,7 +250,7 @@ export default class WinIpCameraService implements IHuddlyService {
     return new Promise((resolve, reject) => {
       this.grpcClient.setUserPTZ(allowed, (err: grpc.ServiceError) => {
         if (err) {
-          this.logger.error(
+          Logger.error(
             `Unable to set user ptz on service. Error: ${err.details}`,
             err.stack,
             WinIpCameraService.name
@@ -283,7 +274,7 @@ export default class WinIpCameraService implements IHuddlyService {
         new Empty(),
         (err: grpc.ServiceError, isAllowed: winservice.UserPtz) => {
           if (err) {
-            this.logger.error(
+            Logger.error(
               `Unable to get information whether user ptz is allowed or not on the service. Error: ${err.details}`,
               err.stack,
               WinIpCameraService.name

--- a/src/components/upgrader/boxfishUpgrader.ts
+++ b/src/components/upgrader/boxfishUpgrader.ts
@@ -11,6 +11,7 @@ import Api from '../api';
 import { calculate } from './../../utilitis/crc32c';
 import CameraEvents from './../../utilitis/events';
 import TypeHelper from './../../utilitis/typehelper';
+import Logger from './../../utilitis/logger';
 import Boxfish from './../device/boxfish';
 import UpgradeStatus, { UpgradeStatusStep } from './upgradeStatus';
 
@@ -21,7 +22,6 @@ import { HPK_SUPPORT_VERSION } from './../upgrader/boxfishUpgraderFactory';
 export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgrader {
   _cameraManager: IDeviceManager;
   _sdkDeviceDisoveryEmitter: EventEmitter;
-  _logger: any;
   _boxfishPackage: IBoxfishUpgraderFile;
   locksmith: Locksmith;
   options: any = {};
@@ -37,11 +37,10 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
     throw new Error('Unable to talk to device. Tarnsport must be UsbTransport compatible');
   }
 
-  constructor(manager: IDeviceManager, sdkDeviceDiscoveryEmitter: EventEmitter, logger: any) {
+  constructor(manager: IDeviceManager, sdkDeviceDiscoveryEmitter: EventEmitter) {
     super();
     this._cameraManager = manager;
     this._sdkDeviceDisoveryEmitter = sdkDeviceDiscoveryEmitter;
-    this._logger = logger;
     this.locksmith = new Locksmith();
   }
 
@@ -90,7 +89,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
       rebootStep,
       verificationStep,
     ]);
-    this._logger.debug('Starting Upgrade', 'Boxfish PKG Upgrader');
+    Logger.debug('Starting Upgrade', 'Boxfish PKG Upgrader');
     this.emitProgressStatus('Starting upgrade');
     this.emit(CameraEvents.UPGRADE_START);
     firstUploadStatusStep.progress = 1;
@@ -98,7 +97,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
     firstUploadStatusStep.progress = 100;
     this.emitProgressStatus();
     rebootStep.progress = 1;
-    this._logger.debug('Rebooting Camera', 'Boxfish PKG Upgrader');
+    Logger.debug('Rebooting Camera', 'Boxfish PKG Upgrader');
     this.emitProgressStatus('Rebooting camera');
 
     // Timeout if the camera does not come back up after bootTimeout seconds have passed!
@@ -108,16 +107,16 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
     }, this.bootTimeout);
 
     this.once('UPGRADE_REBOOT_COMPLETE', async () => {
-      this._logger.debug('Camerea successfully booted after upgrade', 'Boxfish PKG Upgrader');
+      Logger.debug('Camerea successfully booted after upgrade', 'Boxfish PKG Upgrader');
       try {
         rebootStep.progress = 100;
         this.emitProgressStatus();
         verificationStep.progress = 1;
-        this._logger.debug('Verifying new software', 'Boxfish PKG Upgrader');
+        Logger.debug('Verifying new software', 'Boxfish PKG Upgrader');
         this.emitProgressStatus('Verifying new software');
         await this.postUpgrade(state);
         verificationStep.progress = 100;
-        this._logger.debug('Upgrade Completed', 'Boxfish PKG Upgrader');
+        Logger.debug('Upgrade Completed', 'Boxfish PKG Upgrader');
         this.emitProgressStatus('Upgrade complete');
         clearTimeout(bootTimeout);
         this.emit(CameraEvents.UPGRADE_COMPLETE, this._cameraManager);
@@ -152,7 +151,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
   }
 
   async legacyWriteBuf(buf: Buffer, offset: number = 0): Promise<any> {
-    this._logger.debug('Falling back to legacy async file transfer', 'Boxfish PKG Upgrader');
+    Logger.debug('Falling back to legacy async file transfer', 'Boxfish PKG Upgrader');
     const sendData = {
       size: buf.length,
       offset,
@@ -175,7 +174,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
         });
       return true;
     } catch (e) {
-      this._logger.error('Signle Write Buffer not supported in this firmware', e, 'Boxfish PKG Upgrader');
+      Logger.error('Signle Write Buffer not supported in this firmware', e, 'Boxfish PKG Upgrader');
       return false;
     }
   }
@@ -207,7 +206,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
   }
 
   async postUpgrade(upgradeSelection: string): Promise<boolean> {
-    this._logger.debug('Performing post upgrade steps', 'Boxfish PKG Upgrader');
+    Logger.debug('Performing post upgrade steps', 'Boxfish PKG Upgrader');
     await this.printBootInfo();
     await this.setFlashBootState(upgradeSelection);
     await this.setRamBootSelector(upgradeSelection);
@@ -230,7 +229,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
           .then((data) => {
             const receivedCmd = data.message;
             if (receivedCmd !== cmdResult) {
-              this._logger.warn(`Received unexpected ${receivedCmd}. Expected ${cmdResult}`, 'Boxfish PKG Upgrader');
+              Logger.warn(`Received unexpected ${receivedCmd}. Expected ${cmdResult}`, 'Boxfish PKG Upgrader');
               reject(`Received unexpected ${receivedCmd}. Expected ${cmdResult}.`);
             } else {
               const args = Api.decode(data.payload, 'messagepack');
@@ -239,7 +238,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
             }
           })
           .catch((e) => {
-            this._logger.error('Checksum receive message failure', e, 'Boxfish PKG Upgrader');
+            Logger.error('Checksum receive message failure', e, 'Boxfish PKG Upgrader');
             reject(e);
           });
 
@@ -276,11 +275,11 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
                 statusFn(size, size);
                 this.transport.removeAllListeners(cmds.status);
               } else {
-                this._logger.debug('Stage Completed', 'Boxfish PKG Upgrader');
+                Logger.debug('Stage Completed', 'Boxfish PKG Upgrader');
               }
               resolve();
             } else {
-              this._logger.warn(`Flash command ${cmd} failed with ${args.error_count} errors`, 'Boxfish PKG Upgrader');
+              Logger.warn(`Flash command ${cmd} failed with ${args.error_count} errors`, 'Boxfish PKG Upgrader');
               reject(`Flash command ${cmd} failed with ${args.error_count} errors`);
             }
           });
@@ -318,35 +317,35 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
       status = (progress, total) => {
         const now = Date.now();
         if (progress < lastProgress || progress === total || now > lastTime + 1) {
-          this._logger.info(`Status: ${Math.ceil(100 * (progress / total))}%\r`);
+          Logger.info(`Status: ${Math.ceil(100 * (progress / total))}%\r`);
           lastTime = now;
           lastProgress = progress;
           if (progress === total) {
-            this._logger.info('');
+            Logger.info('');
           }
         }
       };
     }
 
     const addr = parseInt(address, 16);
-    this._logger.info(`Allocating buf.. ${buffer.length}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Allocating buf.. ${buffer.length}`, 'Boxfish PKG Upgrader');
     await this.allocateBuf(buffer.length);
-    this._logger.info('Uploading data to camera...', 'Boxfish PKG Upgrader');
+    Logger.info('Uploading data to camera...', 'Boxfish PKG Upgrader');
     await this.writeBuf(buffer);
-    this._logger.info('Calculating checksum on target...', 'Boxfish PKG Upgrader');
+    Logger.info('Calculating checksum on target...', 'Boxfish PKG Upgrader');
     const expectedCrc = calculate(buffer);
     const crc = await this.checksumBuf(buffer.length);
     if (expectedCrc !== crc) {
       throw new Error(`Expected crc ${expectedCrc}, got crc ${crc}`);
     }
     const eraseLen = Math.ceil(buffer.length / 4096) * 4096;
-    this._logger.info(`Erasing... addr: ${addr}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Erasing... addr: ${addr}`, 'Boxfish PKG Upgrader');
     await this.eraseFlash(addr, eraseLen, status);
-    this._logger.info('Writing...', 'Boxfish PKG Upgrader');
+    Logger.info('Writing...', 'Boxfish PKG Upgrader');
     await this.writeFlash(addr, buffer.length, status);
-    this._logger.info('Reading from flash to memory...', 'Boxfish PKG Upgrader');
+    Logger.info('Reading from flash to memory...', 'Boxfish PKG Upgrader');
     await this.readFlashIntoBuf(addr, buffer.length, status);
-    this._logger.info('Calculating checksum...', 'Boxfish PKG Upgrader');
+    Logger.info('Calculating checksum...', 'Boxfish PKG Upgrader');
     const flashCrc = await this.checksumBuf(buffer.length);
     if (expectedCrc !== flashCrc) {
       throw new Error(`Expected crc ${expectedCrc}, got crc ${flashCrc}`);
@@ -354,17 +353,17 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
   }
 
   async flashFsbl(fsblMvcmd: Buffer): Promise<any> {
-    this._logger.info('Flashing fsbl', 'Boxfish PKG Upgrader');
+    Logger.info('Flashing fsbl', 'Boxfish PKG Upgrader');
     return this.doFlash(fsblMvcmd, '0x00');
   }
 
   async setFlashBootState(state: string): Promise<any> {
-    this._logger.info(`Setting flash boot state to ${state}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Setting flash boot state to ${state}`, 'Boxfish PKG Upgrader');
     return this._cameraManager.api.setProductInfo({ flash_boot_state: state });
   }
 
   async initFlash(fsblMvcmd: Buffer, boxfishUpgraderFile: IBoxfishUpgraderFile): Promise<any> {
-    this._logger.info('Initializing flash', 'Boxfish PKG Upgrader');
+    Logger.info('Initializing flash', 'Boxfish PKG Upgrader');
     await this.flashFsbl(fsblMvcmd);
     /* eslint-disable max-len */
     await this.flashImage(IMAGE_TYPES.SSBL_HEADER, boxfishUpgraderFile, 'C');
@@ -386,15 +385,15 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
   }
 
   async setRamBootSelector(selector: string): Promise<any> {
-    this._logger.info(`Setting ram boot selector to ${selector}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Setting ram boot selector to ${selector}`, 'Boxfish PKG Upgrader');
     return this._cameraManager.api.setProductInfo({ bac_fsbl: { ram_boot_selector: selector } });
   }
 
   async printBootInfo(): Promise<void> {
     const prodInfo = await this._cameraManager.api.getProductInfo();
-    this._logger.info(`Current boot decision: ${prodInfo.bac_fsbl.boot_decision}`, 'Boxfish PKG Upgrader');
-    this._logger.info(`Current flash boot selector: ${prodInfo.flash_boot_state}`, 'Boxfish PKG Upgrader');
-    this._logger.info(`Current ram boot selector: ${prodInfo.bac_fsbl.ram_boot_selector}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Current boot decision: ${prodInfo.bac_fsbl.boot_decision}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Current flash boot selector: ${prodInfo.flash_boot_state}`, 'Boxfish PKG Upgrader');
+    Logger.info(`Current ram boot selector: ${prodInfo.bac_fsbl.ram_boot_selector}`, 'Boxfish PKG Upgrader');
   }
 
   async upgrade(): Promise<string> {
@@ -422,41 +421,41 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
         return 'C';
       }
       const bootDecision = this.getBootDecision(prodInfo);
-      this._logger.info(`Current boot decision ${bootDecision}`, 'Boxfish PKG Upgrader');
+      Logger.info(`Current boot decision ${bootDecision}`, 'Boxfish PKG Upgrader');
       const upgradeSelection = bootDecision === 'A' ? 'B' : 'A';
 
       /* eslint-disable max-len */
-      this._logger.debug('Flashing SSBL_HEADER', 'Boxfish PKG Upgrader');
+      Logger.debug('Flashing SSBL_HEADER', 'Boxfish PKG Upgrader');
       await this.flashImage(IMAGE_TYPES.SSBL_HEADER, boxfishUpgraderFile, upgradeSelection);
-      this._logger.debug('Flashing SSBL', 'Boxfish PKG Upgrader');
+      Logger.debug('Flashing SSBL', 'Boxfish PKG Upgrader');
       await this.flashImage(IMAGE_TYPES.SSBL, boxfishUpgraderFile, upgradeSelection);
-      this._logger.debug('Flashing APPLICATION_HEADER', 'Boxfish PKG Upgrader');
+      Logger.debug('Flashing APPLICATION_HEADER', 'Boxfish PKG Upgrader');
       await this.flashImage(IMAGE_TYPES.APP_HEADER, boxfishUpgraderFile, upgradeSelection);
-      this._logger.debug('Flashing APPLICATION', 'Boxfish PKG Upgrader');
+      Logger.debug('Flashing APPLICATION', 'Boxfish PKG Upgrader');
       await this.flashImage(IMAGE_TYPES.APP, boxfishUpgraderFile, upgradeSelection);
       /* eslint-enable max-len */
       if (semver.gt(currentSwVersion, '0.0.7')) {
-        this._logger.debug('Unlocking UVC stream on camera', 'Boxfish PKG Upgrader');
+        Logger.debug('Unlocking UVC stream on camera', 'Boxfish PKG Upgrader');
         await this.locksmith.executeAsyncFunction(async () => {
           await this.transport.clear();
           await this.transport.write('streaming/unlock');
         });
       }
-      this._logger.debug(`Setting boot selector to ${upgradeSelection}`, 'Boxfish PKG Upgrader');
+      Logger.debug(`Setting boot selector to ${upgradeSelection}`, 'Boxfish PKG Upgrader');
       await this.setRamBootSelector(upgradeSelection);
       await this.printBootInfo();
 
-      this._logger.debug('Booting the camera and closing communication instances', 'Boxfish PKG Upgrader');
+      Logger.debug('Booting the camera and closing communication instances', 'Boxfish PKG Upgrader');
       await this._cameraManager.reboot();
       await this.transport.close();
 
       const finishTime = new Date().getTime();
       const flashTime = (finishTime - startTime) / 1000;
-      this._logger.info(`Upgrade completed in ${flashTime} seconds`, 'Boxfish PKG Upgrader');
+      Logger.info(`Upgrade completed in ${flashTime} seconds`, 'Boxfish PKG Upgrader');
 
       return upgradeSelection;
     } catch (e) {
-      this._logger.error('Boxfish camera upgrade failed', e, 'Boxfish PKG Upgrader');
+      Logger.error('Boxfish camera upgrade failed', e, 'Boxfish PKG Upgrader');
       this.emit(CameraEvents.UPGRADE_FAILED, e);
       throw e;
     }
@@ -472,7 +471,7 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
     try {
       const response = await this._cameraManager.getState();
 
-      this._logger.info(`Upgrade status ${JSON.stringify(response)}`, 'Boxfish PKG Upgrader');
+      Logger.info(`Upgrade status ${JSON.stringify(response)}`, 'Boxfish PKG Upgrader');
       if (response.status === 10) {
         // EMMC is not ready lets wait and try again
         await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/components/upgrader/boxfishUpgraderFactory.ts
+++ b/src/components/upgrader/boxfishUpgraderFactory.ts
@@ -4,6 +4,7 @@ import IDeviceManager from './../../interfaces/iDeviceManager';
 import IDeviceUpgrader from './../../interfaces/IDeviceUpgrader';
 import BoxfishUpgrader from './../upgrader/boxfishUpgrader';
 import HPKUpgrader from './../upgrader/hpkUpgrader';
+import Logger from './../../utilitis/logger';
 
 import BoxfishPkg from './boxfishpkg';
 import BoxfishHpk from './boxfishhpk';
@@ -15,15 +16,14 @@ export const HPK_SUPPORT_VERSION = process.env.HPK_SUPPORT_VERSION || '1.2.1-0';
 export async function createBoxfishUpgrader(
   manager: IDeviceManager,
   sdkDeviceDiscoveryEmitter: EventEmitter,
-  logger: any
 ): Promise<IDeviceUpgrader> {
   const info = await manager.getInfo();
   if (semver.gte(info.version, HPK_SUPPORT_VERSION)) {
-    logger.warn('Initializing HPKUpgrader', 'Boxfish Upgrader Factory');
-    return new HPKUpgrader(manager, sdkDeviceDiscoveryEmitter, logger);
+    Logger.warn('Initializing HPKUpgrader', 'Boxfish Upgrader Factory');
+    return new HPKUpgrader(manager, sdkDeviceDiscoveryEmitter);
   }
-  logger.warn(`Camera version is ${info.version} which is not supported by HPK Upgrader. Using BoxfishUpgrader as fallback.`, 'Boxfish Upgrader Factory');
-  return new BoxfishUpgrader(manager, sdkDeviceDiscoveryEmitter, logger);
+  Logger.warn(`Camera version is ${info.version} which is not supported by HPK Upgrader. Using BoxfishUpgrader as fallback.`, 'Boxfish Upgrader Factory');
+  return new BoxfishUpgrader(manager, sdkDeviceDiscoveryEmitter);
 }
 
 export function createBoxfishUpgraderFile(file: Buffer) {

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,6 @@ When you create an instance of the SDK, you provide some options on the construc
 ```javascript
 const usbApi = new DeviceApiUSB();
 const opts = {
-  logger: new DefaultLogger(),
   //emitter: new EventEmitter(), <- this is an optional parameter
 };
 const sdk = new SDK(usbApi, [usbApi], opts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import AllDeviceDiscovery from './components/allDeviceDiscovery';
 import IHuddlyService from './interfaces/IHuddlyService';
 import IServiceOpts from './interfaces/IServiceOpts';
 import ServiceFactory from './components/service/factory';
+import ILogger from './interfaces/ILogger';
 
 sourceMapSupport.install();
 
@@ -32,13 +33,12 @@ class AttachError extends Error {
  */
 interface SDKOpts {
   /**
-   * @deprecated
    * Logger instance used to log messages from the SDK.
    *
-   * @type {*}
+   * @type {ILogger}
    * @memberof SDKOpts
    */
-  logger?: any;
+  logger?: ILogger;
   /**
    * Optional event emitter instance used to catch
    * SDK events!
@@ -97,15 +97,6 @@ class HuddlySdk extends EventEmitter {
    * @memberof HuddlySdk
    */
   emitter: EventEmitter;
-
-  /**
-   * @deprecated
-   * Logger instance used to log messages from the SDK.
-   *
-   * @type {*}
-   * @memberof HuddlySdk
-   */
-  logger: any;
 
   /**
    * @ignore
@@ -193,6 +184,10 @@ class HuddlySdk extends EventEmitter {
       },
       ...opts,
     };
+
+    if (options.logger) {
+      Logger.setLogger(options.logger);
+    }
 
     this.deviceDiscovery = options.apiDiscoveryEmitter;
     this.emitter = options.emitter;

--- a/src/interfaces/IDeviceApiOpts.ts
+++ b/src/interfaces/IDeviceApiOpts.ts
@@ -8,6 +8,7 @@
  */
 export default interface DeviceApiOpts {
   /**
+   * @deprecated
    * Logger class used for logging varius levels of messages
    * like: warn, info or error!
    *

--- a/src/interfaces/ILogger.ts
+++ b/src/interfaces/ILogger.ts
@@ -1,0 +1,6 @@
+export default interface ILogger {
+  info(message: string): void;
+  debug(message: string): void;
+  warn(message: string): void;
+  error(message: string, stackTrace?: any): void;
+}

--- a/src/interfaces/iDeviceFactory.ts
+++ b/src/interfaces/iDeviceFactory.ts
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 import IHuddlyDeviceAPI from './iHuddlyDeviceAPI';
 import IDeviceManager from './iDeviceManager';
-import iLogger from './iLogger';
 
 /**
  * Factory that is used to create device
@@ -14,7 +13,6 @@ export default interface IDeviceFactory {
    * Returns appropriate IDeviceManager with provided transport for the provided
    * devInstance object.
    * @param {number} productId A usb device product id to distinct betweern different huddly products
-   * @param {DefaultLogger} logger The logger class used for logging messages on console
    * @param {IHuddlyDeviceAPI} preferredDeviceApi The main IHuddlyDeviceAPI used for communicating
    * with the camera
    * @param {Array<IHuddlyDeviceAPI>} secondaryDeviceApis Fallback IHuddlyDeviceAPI-s in case the
@@ -25,7 +23,6 @@ export default interface IDeviceFactory {
    */
   getDevice(
     productId: number,
-    logger: iLogger,
     preferredDeviceApi: IHuddlyDeviceAPI,
     secondaryDeviceApis: Array<IHuddlyDeviceAPI>,
     devInstance: any,

--- a/src/interfaces/iDeviceManager.ts
+++ b/src/interfaces/iDeviceManager.ts
@@ -43,16 +43,6 @@ export default interface IDeviceManager {
   uvcControlInterface: any;
 
   /**
-   * Utility class used to log messages (used for debugging purposes). Required
-   * class/object methods are "info", "warn" and "error" with each method
-   * having a string parameter that describes the log message!
-   *
-   * @type {any}
-   * @memberof IDeviceManager
-   */
-  logger: any;
-
-  /**
    * Class initialization function.
    *
    * @returns {Promise<void>}

--- a/src/interfaces/iLogger.ts
+++ b/src/interfaces/iLogger.ts
@@ -1,9 +1,0 @@
-export default interface ILogger {
-  warn(message: string, component: string): void;
-
-  info(message: string, component: string): void;
-
-  debug(message: string, component: string): void;
-
-  error(message: string, stackTrace: any, component: string): void;
-}

--- a/src/utilitis/logger.ts
+++ b/src/utilitis/logger.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import ILogger from './../interfaces/ILogger';
 
 /**
  * Huddly Logger class.
@@ -30,26 +31,52 @@ import fs from 'fs';
  * node sdkexample.js
  */
 export default class Logger {
+  static customLogger: ILogger = undefined;
+
+  static setLogger(logger: ILogger): void {
+    Logger.customLogger = logger;
+  }
+
   static warn(message: string, component: string = 'Generic Component'): void {
     if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
+      if (Logger.customLogger) {
+        Logger.customLogger.warn(message);
+        return;
+      }
+
       this.redirectLogMsg(this.formatLogMsg('WARN', component, message));
     }
   }
 
   static info(message: string, component: string = 'Generic Component'): void {
     if (['INFO', 'DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
+      if (Logger.customLogger) {
+        Logger.customLogger.info(message);
+        return;
+      }
+
       this.redirectLogMsg(this.formatLogMsg('INFO', component, message));
     }
   }
 
   static debug(message: string, component: string = 'Generic Component'): void {
     if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
+      if (Logger.customLogger) {
+        Logger.customLogger.debug(message);
+        return;
+      }
+
       this.redirectLogMsg(this.formatLogMsg('DEBUG', component, message));
     }
   }
 
   static error(message: string, stackTrace: any, component: string = 'Generic Component'): void {
     if (['NONE'].indexOf(process.env.HUDDLY_LOG_LEVEL) == -1) {
+      if (Logger.customLogger) {
+        Logger.customLogger.error(message, stackTrace);
+        return;
+      }
+
       this.redirectLogMsg(this.formatLogMsg('ERROR', component, message));
       this.redirectLogMsg(stackTrace);
     }

--- a/src/utilitis/logger.ts
+++ b/src/utilitis/logger.ts
@@ -1,52 +1,58 @@
+/**
+ * Huddly Logger class. Use HUDDLY_LOG_LEVEL env variable
+ * to configure the log level on the SDK.
+ *
+ * Use the following
+ * values:
+ * - DEBUG - log all gRPC messages
+ * - INFO - log INFO and ERROR message
+ * - ERROR - log only errors (default)
+ * - NONE - won't log any
+ */
 export default class Logger {
-  _verbose: boolean;
-
-  constructor(verbose: boolean) {
-    this._verbose = verbose;
-  }
-
-  warn(message: string, component: string = 'Generic Component'): void {
-    if (this.verbose) {
+  static warn(message: string, component: string = 'Generic Component'): void {
+    if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
       console.warn(this.formatLogMsg('WARN', component, message));
     }
   }
 
-  info(message: string, component: string = 'Generic Component'): void {
-    if (this.verbose) {
+  static info(message: string, component: string = 'Generic Component'): void {
+    if (['INFO'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
       console.log(this.formatLogMsg('INFO', component, message));
     }
   }
 
-  debug(message: string, component: string = 'Generic Component'): void {
-    if (this.verbose) {
+  static debug(message: string, component: string = 'Generic Component'): void {
+    if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
       console.log(this.formatLogMsg('DEBUG', component, message));
     }
   }
 
-  error(message: string, stackTrace: any, component: string = 'Generic Component'): void {
-    if (this.verbose) {
-      console.error(this.formatLogMsg('ERROR', component, message));
-      console.error(stackTrace);
+  static error(message: string, stackTrace: any, component: string = 'Generic Component'): void {
+    if (['NONE'].indexOf(process.env.HUDDLY_LOG_LEVEL) == -1) {
+      this.redirectLogMsg(this.formatLogMsg('ERROR', component, message));
+      this.redirectLogMsg(stackTrace);
     }
   }
 
-  get verbose(): boolean {
-    return this._verbose;
+  static redirectLogMsg(message: string): void {
+    if (process.env.HUDDLY_LOG_CHANNEL === 'FILE') {
+      const logFile: string = process.env.HUDDLY_LOG_FILE || 'huddlysdk.log';
+      fs.appendFileSync(logFile, `${message}\n`);
+    } else {
+      console.log(message);
+    }
   }
 
-  set verbose(verbose: boolean) {
-    this._verbose = verbose;
-  }
-
-  private formatDate(date: Date): string {
+  private static formatDate(date: Date): string {
     return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
   }
 
-  private getTime(date: Date): string {
+  private static getTime(date: Date): string {
     return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}:${date.getMilliseconds()}`;
   }
 
-  private formatLogMsg(logLevel: string, component: string, message: string): string {
+  private static formatLogMsg(logLevel: string, component: string, message: string): string {
     const now = new Date();
     return `${this.formatDate(now)} | ${this.getTime(
       now

--- a/src/utilitis/logger.ts
+++ b/src/utilitis/logger.ts
@@ -1,30 +1,50 @@
+import fs from 'fs';
+
 /**
- * Huddly Logger class. Use HUDDLY_LOG_LEVEL env variable
- * to configure the log level on the SDK.
+ * Huddly Logger class.
  *
- * Use the following
- * values:
+ * Use HUDDLY_LOG_LEVEL env variable to configure the log level on the SDK. The following values apply
  * - DEBUG - log all gRPC messages
  * - INFO - log INFO and ERROR message
  * - ERROR - log only errors (default)
  * - NONE - won't log any
+ *
+ * Use HUDDLY_LOG_CHANNEL env variable to configure where the logs will be directed to. The following
+ * values apply:
+ * - CONSOLE - Write logs to system console
+ * - FILE - Write logs to a dedicated file provided by HUDDLY_LOG_FILE
+ *
+ * USE HUDDLY_LOG_FILE env variable to specify the file where the logs will be directed to.
+ *
+ * @example
+ * // Print all logs and redirect them to a file
+ * export HUDDLY_LOG_LEVEL=DEBUG && HUDDLY_LOG_CHANNEL=FILE && HUDDLY_LOG_FILE=/users/johndoe/huddlysdk.log
+ * node sdkexample.js
+ *
+ * // Print INFO && ERROR logs and redirect them to console out
+ * export HUDDLY_LOG_LEVEL=INFO
+ * node sdkexample.js
+ *
+ * // Disable all log output
+ * export HUDDLY_LOG_LEVEL=NONE
+ * node sdkexample.js
  */
 export default class Logger {
   static warn(message: string, component: string = 'Generic Component'): void {
     if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
-      console.warn(this.formatLogMsg('WARN', component, message));
+      this.redirectLogMsg(this.formatLogMsg('WARN', component, message));
     }
   }
 
   static info(message: string, component: string = 'Generic Component'): void {
-    if (['INFO'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
-      console.log(this.formatLogMsg('INFO', component, message));
+    if (['INFO', 'DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
+      this.redirectLogMsg(this.formatLogMsg('INFO', component, message));
     }
   }
 
   static debug(message: string, component: string = 'Generic Component'): void {
     if (['DEBUG'].indexOf(process.env.HUDDLY_LOG_LEVEL) > -1) {
-      console.log(this.formatLogMsg('DEBUG', component, message));
+      this.redirectLogMsg(this.formatLogMsg('DEBUG', component, message));
     }
   }
 

--- a/tests/components/api.spec.ts
+++ b/tests/components/api.spec.ts
@@ -6,7 +6,6 @@ import nock from 'nock';
 import Api from './../../src/components/api';
 import Locksmith from './../../src/components/locksmith';
 import ITransport from './../../src/interfaces/iTransport';
-import DefaultLogger from './../../src/utilitis/logger';
 import ReleaseChannel from './../../src/interfaces/ReleaseChannelEnum';
 
 chai.should();
@@ -35,9 +34,7 @@ class NodeUsbTransport implements ITransport {
 const createDummyTransport = () => {
   return sinon.createStubInstance(NodeUsbTransport);
 };
-const createDummyLogger = (): DefaultLogger => {
-  return sinon.createStubInstance(DefaultLogger);
-};
+
 describe('API', () => {
   let transport;
   let api;
@@ -47,7 +44,7 @@ describe('API', () => {
     transport.write.returns(Promise.resolve());
     transport.subscribe.returns(Promise.resolve());
     transport.unsubscribe.returns(Promise.resolve());
-    api = new Api(transport, createDummyLogger(), new Locksmith());
+    api = new Api(transport, new Locksmith());
   });
   describe('#sendAndReceiveMessagePack', () => {
     it('should encode message, perform sendAndRecieve and decode received message', async () => {

--- a/tests/components/autozoomControl.spec.ts
+++ b/tests/components/autozoomControl.spec.ts
@@ -2,14 +2,9 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import AutozoomControl from '../../src/components/autozoomControl';
 import IDeviceManager from '../../src/interfaces/iDeviceManager';
-import DefaultLogger from '../../src/utilitis/logger';
 import Api from '../../src/components/api';
 import DeviceManagerMock from '../mocks/devicemanager.mock';
 import AutozoomControlOpts from '../../src/interfaces/IAutozoomControlOpts';
-
-const createDummyLogger = (): DefaultLogger => {
-  return sinon.createStubInstance(DefaultLogger);
-};
 
 describe('AutozoomControl', () => {
   let autozoomControl: AutozoomControl;
@@ -17,7 +12,7 @@ describe('AutozoomControl', () => {
 
   beforeEach(() => {
     deviceManager = new DeviceManagerMock();
-    autozoomControl = new AutozoomControl(deviceManager, createDummyLogger());
+    autozoomControl = new AutozoomControl(deviceManager);
   });
 
   describe('#init', () => {
@@ -32,7 +27,7 @@ describe('AutozoomControl', () => {
     describe('on shouldAutoFrame option set', () => {
       describe('on shouldAutoFrame: true', () => {
         it('should set AUTO_PTZ framing config to true', async () => {
-          autozoomControl = new AutozoomControl(deviceManager, createDummyLogger(), { shouldAutoFrame: true });
+          autozoomControl = new AutozoomControl(deviceManager, { shouldAutoFrame: true });
           await autozoomControl.init();
           expect(uploadFramingConfigStub.callCount).to.equals(1);
           expect(uploadFramingConfigStub.firstCall.args[0]).to.deep.equals({ AUTO_PTZ: true });
@@ -40,7 +35,7 @@ describe('AutozoomControl', () => {
       });
       describe('on shouldAutoFrame: false', () => {
         it('should set AUTO_PTZ framing config to false', async () => {
-          autozoomControl = new AutozoomControl(deviceManager, createDummyLogger(), { shouldAutoFrame: false });
+          autozoomControl = new AutozoomControl(deviceManager, { shouldAutoFrame: false });
           await autozoomControl.init();
           expect(uploadFramingConfigStub.callCount).to.equals(1);
           expect(uploadFramingConfigStub.firstCall.args[0]).to.deep.equals({ AUTO_PTZ: false });
@@ -50,7 +45,7 @@ describe('AutozoomControl', () => {
 
     describe('on shouldAutoFrame option not set', () => {
       it('should not call #uploadFramingConfig when shouldAutoFrame options is not provided', async () => {
-        autozoomControl = new AutozoomControl(deviceManager, createDummyLogger(), {});
+        autozoomControl = new AutozoomControl(deviceManager, {});
         await autozoomControl.init();
         expect(uploadFramingConfigStub.callCount).to.equals(0);
       });

--- a/tests/components/device/ace.spec.ts
+++ b/tests/components/device/ace.spec.ts
@@ -5,7 +5,7 @@ import sinonChai from 'sinon-chai';
 import IGrpcTransport from './../../../src/interfaces/IGrpcTransport';
 import { HuddlyServiceClient } from '@huddly/huddlyproto/lib/proto/huddly_grpc_pb';
 import * as huddly from '@huddly/huddlyproto/lib/proto/huddly_pb';
-import DefaultLogger from './../../../src/utilitis/logger';
+import Logger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import Ace, { minMax } from './../../../src/components/device/ace';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb';
@@ -89,12 +89,20 @@ describe('Ace', () => {
     },
   };
 
+  let warnStub, errorStub, infoStub;
+
   beforeEach(() => {
-    device = new Ace({}, dummyTransport, new DefaultLogger(false), new EventEmitter());
+    device = new Ace({}, dummyTransport, new EventEmitter());
     sinon.spy(device, 'handleError');
-    sinon.stub(device.logger, 'warn');
-    sinon.stub(device.logger, 'error');
-    sinon.stub(device.logger, 'info');
+    warnStub = sinon.stub(Logger, 'warn');
+    errorStub = sinon.stub(Logger, 'error');
+    infoStub = sinon.stub(Logger, 'info');
+  });
+
+  afterEach(() => {
+    warnStub.restore();
+    errorStub.restore();
+    infoStub.restore();
   });
 
   describe('#_getTemperatures', () => {
@@ -192,7 +200,6 @@ describe('Ace', () => {
       const arg = dummyTransport.grpcClient.setSaturation.args[0][0];
       expect(arg).to.be.instanceof(huddly.Saturation);
       expect(arg.getSaturation()).to.equal(99);
-      expect(device.logger.info).to.have.been.calledWith(statusDummy);
     });
     it('should handle error if there is an issue', async () => {
       dummyTransport.grpcClient.setSaturation = (empty: Empty, cb: any) => {
@@ -248,7 +255,6 @@ describe('Ace', () => {
       const arg = dummyTransport.grpcClient.setBrightness.args[0][0];
       expect(arg).to.be.instanceof(huddly.Brightness);
       expect(arg.getBrightness()).to.equal(5);
-      expect(device.logger.info).to.have.been.calledWith(statusDummy);
     });
     it('should handle error if there is an issue', async () => {
       dummyTransport.grpcClient.setSaturation = (empty: Empty, cb: any) => {
@@ -310,7 +316,6 @@ describe('Ace', () => {
       });
       expect(dummyTransport.grpcClient.setPTZ).to.be.called;
       expect(dummyTransport.grpcClient.setPTZ.args[0][0]).to.be.instanceof(huddly.PTZ);
-      expect(device.logger.info).to.have.been.calledWith(statusDummy);
     });
     it('should handle error if there is an issue', async () => {
       dummyTransport.grpcClient.setPTZ = (ptz: huddly.PTZ, cb: any) => {
@@ -448,7 +453,7 @@ describe('Ace', () => {
       try {
         await device.getSetting('dummy');
       } catch (err) {
-        expect(device.logger.warn).to.have.been.calledOnce;
+        expect(Logger.warn).to.have.been.calledOnce;
       }
     });
     it('should throw a rejection if something happens', async () => {
@@ -481,7 +486,7 @@ describe('Ace', () => {
       try {
         await device.setSettingValue('dummy', 1);
       } catch (err) {
-        expect(device.logger.warn).to.have.been.calledOnce;
+        expect(Logger.warn).to.have.been.calledOnce;
       }
     });
     it('should throw a rejection if something happens', async () => {

--- a/tests/components/device/boxfish.spec.ts
+++ b/tests/components/device/boxfish.spec.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import ITransport from './../../../src/interfaces/iTransport';
 import IDeviceUpgrader from './../../../src/interfaces/IDeviceUpgrader';
 import Boxfish from './../../../src/components/device/boxfish';
-import DefaultLogger from './../../../src/utilitis/logger';
+import Logger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import CameraEvents from './../../../src/utilitis/events';
 import Api from './../../../src/components/api';
@@ -75,7 +75,6 @@ describe('Boxfish', () => {
       {},
       sinon.createStubInstance(DummyTransport),
       {},
-      new DefaultLogger(false),
       new EventEmitter(),
     );
   });

--- a/tests/components/device/dartfish.spec.ts
+++ b/tests/components/device/dartfish.spec.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import ITransport from './../../../src/interfaces/iTransport';
 import IDeviceUpgrader from './../../../src/interfaces/IDeviceUpgrader';
 import Dartfish from './../../../src/components/device/dartfish';
-import DefaultLogger from './../../../src/utilitis/logger';
+import Logger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import CameraEvents from './../../../src/utilitis/events';
 import Api from './../../../src/components/api';
@@ -75,7 +75,6 @@ describe('Dartfish', () => {
       {},
       sinon.createStubInstance(DummyTransport),
       {},
-      new DefaultLogger(false),
       new EventEmitter(),
     );
   });

--- a/tests/components/device/dwarffish.spec.ts
+++ b/tests/components/device/dwarffish.spec.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import ITransport from '../../../src/interfaces/iTransport';
 import IDeviceUpgrader from '../../../src/interfaces/IDeviceUpgrader';
 import Dwarffish from '../../../src/components/device/dwarffish';
-import DefaultLogger from '../../../src/utilitis/logger';
+import Logger from '../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 import CameraEvents from '../../../src/utilitis/events';
 import Api from '../../../src/components/api';
@@ -63,7 +63,6 @@ describe('Dwarffish', () => {
       {},
       sinon.createStubInstance(DummyTransport),
       {},
-      new DefaultLogger(false),
       new EventEmitter(),
     );
   });

--- a/tests/components/device/huddlygo.spec.ts
+++ b/tests/components/device/huddlygo.spec.ts
@@ -4,7 +4,7 @@ import sinonChai from 'sinon-chai';
 
 import ITransport from './../../../src/interfaces/iTransport';
 import HuddlyGo from './../../../src/components/device/huddlygo';
-import DefaultLogger from './../../../src/utilitis/logger';
+import Logger from './../../../src/utilitis/logger';
 import { EventEmitter } from 'events';
 
 chai.should();
@@ -58,7 +58,6 @@ describe('HuddlyGO', () => {
       sinon.createStubInstance(DummyTransport),
       {},
       {},
-      new DefaultLogger(false),
       new EventEmitter(),
     );
 

--- a/tests/components/faceBasedExposureControl.spec.ts
+++ b/tests/components/faceBasedExposureControl.spec.ts
@@ -2,12 +2,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import FaceBasedExposureControl from '../../src/components/faceBasedExposureControl';
 import IDeviceManager from '../../src/interfaces/iDeviceManager';
-import DefaultLogger from '../../src/utilitis/logger';
 import DeviceManagerMock from '../mocks/devicemanager.mock';
-
-const createDummyLogger = (): DefaultLogger => {
-  return sinon.createStubInstance(DefaultLogger);
-};
 
 describe('FaceBasedExposureControl', () => {
   let faceBasedExposureControl: FaceBasedExposureControl;
@@ -15,7 +10,7 @@ describe('FaceBasedExposureControl', () => {
 
   beforeEach(() => {
     deviceManager = new DeviceManagerMock();
-    faceBasedExposureControl = new FaceBasedExposureControl(deviceManager, createDummyLogger());
+    faceBasedExposureControl = new FaceBasedExposureControl(deviceManager);
   });
 
   describe('autozoom enable/disable', () => {

--- a/tests/components/service/factory.spec.ts
+++ b/tests/components/service/factory.spec.ts
@@ -4,23 +4,16 @@ import sinonChai from 'sinon-chai';
 
 import IHuddlyService from './../../../src/interfaces/IHuddlyService';
 import ServiceFactory from './../../../src/components/service/factory';
-import Logger from './../../../src/utilitis/logger';
 import WinIpCameraService from './../../../src/components/service/winIpCameraService';
 
 chai.should();
 chai.use(sinonChai);
 
-const stubLogger = () => {
-  return sinon.createStubInstance(Logger);
-};
-
 describe('ServiceFactory', () => {
-  let dummyLogger;
   let platformMock;
 
   beforeEach(() => {
     platformMock = sinon.stub(process, 'platform');
-    dummyLogger = stubLogger();
   });
 
   afterEach(() => {
@@ -30,26 +23,26 @@ describe('ServiceFactory', () => {
   describe('#getService', () => {
     it('should create new instance of WinIpCameraService when on Windows os', () => {
       platformMock.value('win32');
-      const service: IHuddlyService = ServiceFactory.getService(dummyLogger, {});
+      const service: IHuddlyService = ServiceFactory.getService({});
       expect(service).to.be.instanceof(WinIpCameraService);
     });
 
     it('should throw error when running on ubuntu', () => {
       const platform = 'linux';
       platformMock.value(platform);
-      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      const badFunc = () => { ServiceFactory.getService({}); };
       expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
     });
     it('should throw error when running on osx', () => {
       const platform = 'darwin';
       platformMock.value(platform);
-      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      const badFunc = () => { ServiceFactory.getService({}); };
       expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
     });
     it('should throw error when running on other os', () => {
       const platform = 'helloworld';
       platformMock.value(platform);
-      const badFunc = () => { ServiceFactory.getService(dummyLogger, {}); };
+      const badFunc = () => { ServiceFactory.getService({}); };
       expect(badFunc).to.throw(`Currently there is no Huddly Service support for platform ${platform}`);
     });
   });

--- a/tests/components/service/winIpCameraService.spec.ts
+++ b/tests/components/service/winIpCameraService.spec.ts
@@ -6,7 +6,6 @@ import Logger from './../../../src/utilitis/logger';
 import WinIpCameraService, { ServiceCameraActions } from './../../../src/components/service/winIpCameraService';
 import { HuddlyCameraServiceClient } from '@huddly/huddlyproto/lib/proto/win_service_grpc_pb';
 import * as winservice from '@huddly/huddlyproto/lib/proto/win_service_pb';
-import iLogger from './../../../src/interfaces/iLogger';
 
 
 chai.should();
@@ -16,8 +15,8 @@ const stubLogger = () => {
   return sinon.createStubInstance(Logger);
 };
 
-const createServiceInstance = (dummyLogger: iLogger): WinIpCameraService => {
-  const service = new WinIpCameraService(dummyLogger, {});
+const createServiceInstance = (): WinIpCameraService => {
+  const service = new WinIpCameraService({});
   const grpcClientMock = sinon.createStubInstance(HuddlyCameraServiceClient, {
     setActiveCamera: sinon.stub(),
     setDefaultCamera: sinon.stub(),
@@ -32,11 +31,9 @@ const createServiceInstance = (dummyLogger: iLogger): WinIpCameraService => {
 
 describe('WinIpCameraService', () => {
   let service: WinIpCameraService;
-  let dummyLogger;
 
   beforeEach(() => {
-    dummyLogger = stubLogger();
-    service = createServiceInstance(dummyLogger);
+    service = createServiceInstance();
   });
 
   describe('#init', () => {

--- a/tests/components/upgrader/aceUpgrader.spec.ts
+++ b/tests/components/upgrader/aceUpgrader.spec.ts
@@ -8,7 +8,6 @@ import fs from 'fs';
 import AceUpgrader, { UpgradeSteps } from './../../../src/components/upgrader/aceUpgrader';
 import Ace from './../../../src/components/device/ace';
 import Boxfish from './../../../src/components/device/boxfish';
-import DefaultLogger from './../../../src/utilitis/logger';
 import { CameraEvents } from './../../../src';
 import AceUpgraderError from './../../../src/error/AceUpgraderError';
 
@@ -36,8 +35,6 @@ const createDummyManager = () => {
   return dummyManager;
 };
 
-
-const dummyLogger = sinon.createStubInstance(DefaultLogger);
 const dummyEmitter = new EventEmitter();
 
 describe('AceUpgrader', () => {
@@ -45,7 +42,7 @@ describe('AceUpgrader', () => {
   let dummyManager;
   beforeEach(() => {
     dummyManager = createDummyManager();
-    upgrader = new AceUpgrader(dummyManager, dummyEmitter, dummyLogger);
+    upgrader = new AceUpgrader(dummyManager, dummyEmitter);
   });
 
   describe('getters', () => {
@@ -55,7 +52,7 @@ describe('AceUpgrader', () => {
         expect(manager).to.be.an.instanceof(Ace);
       });
       it('should throw error if instance is not Ace', () => {
-        upgrader = new AceUpgrader(sinon.createStubInstance(Boxfish), dummyEmitter, dummyLogger);
+        upgrader = new AceUpgrader(sinon.createStubInstance(Boxfish), dummyEmitter);
         const badFn = () => { upgrader.aceManager; };
         expect(badFn).to.throw('Ace upgrader initialized with wrong camera manager! Manager is not instance of Ace but => Boxfish');
       });

--- a/tests/components/upgrader/hpkUpgrader.spec.ts
+++ b/tests/components/upgrader/hpkUpgrader.spec.ts
@@ -7,7 +7,6 @@ import fs from 'fs';
 import path from 'path';
 
 import HPKUpgrader from './../../../src/components/upgrader/hpkUpgrader';
-import DefaultLogger from './../../../src/utilitis/logger';
 import Boxfish from './../../../src/components/device/boxfish';
 import CameraEvents from './../../../src/utilitis/events';
 import Api from './../../../src/components/api';
@@ -33,7 +32,7 @@ describe('HPKUpgrader', () => {
     dummyCameraManager.transport = new EventEmitter();
     dummyCameraManager.transport.close = () => {};
     dummyCameraManager.transport.stopEventLoop = () => {};
-    hpkUpgrader = new HPKUpgrader(dummyCameraManager, dummyEmitter, new DefaultLogger(false));
+    hpkUpgrader = new HPKUpgrader(dummyCameraManager, dummyEmitter);
   });
 
   describe('#init', () => {

--- a/tests/mocks/devicemanager.mock.ts
+++ b/tests/mocks/devicemanager.mock.ts
@@ -34,7 +34,6 @@ export default class DeviceManagerMock implements IDeviceManager {
     transport: this.transport,
   };
   uvcControlInterface: any;
-  logger: any;
   initialize(): Promise<void> { return Promise.resolve(); }
   closeConnection(): Promise<void> { return Promise.resolve(); }
   getInfo(): Promise<object> { return Promise.resolve({ version: '99.99.99' }); }

--- a/tests/utilities/logger.spec.ts
+++ b/tests/utilities/logger.spec.ts
@@ -4,10 +4,18 @@ import sinonChai from 'sinon-chai';
 import fs from 'fs';
 
 import Logger from './../../src/utilitis/logger';
+import ILogger from './../../src/interfaces/ILogger';
 
 
 chai.should();
 chai.use(sinonChai);
+
+class CustomLogger {
+    info(msg) {}
+    debug(msg) {}
+    warn(msg) {}
+    error(msg, stackTrace) {}
+}
 
 describe('Logger', () => {
     afterEach(() => {
@@ -23,119 +31,174 @@ describe('Logger', () => {
         afterEach(() => {
             formatLogMsgSpy.restore();
         });
-        describe('#info', () => {
-            it('should should log messages when HUDDLY_LOG_LEVEL is INFO', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'INFO';
-                Logger.info(logMsg, 'TESTCOMPONENT');
-                expect(formatLogMsgSpy.called).to.equal(true);
-                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
-                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
-                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
-            });
-            it('should should log messages when HUDDLY_LOG_LEVEL is DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
-                Logger.info(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(true);
-                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
-                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('Generic Component');
-                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
-            });
-            it('should not log anything when HUDDLY_LOG_LEVEL is neither INFO or DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
-                Logger.info(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-                process.env.HUDDLY_LOG_LEVEL = 'NONE';
-                Logger.info(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-            });
-        });
-        describe('#debug', () => {
-            it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
-                Logger.debug(logMsg, 'TESTCOMPONENT');
-                expect(formatLogMsgSpy.called).to.equal(true);
-                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('DEBUG');
-                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
-                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
-            });
-            it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
-                Logger.debug(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-                process.env.HUDDLY_LOG_LEVEL = 'INFO';
-                Logger.debug(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-                process.env.HUDDLY_LOG_LEVEL = 'NONE';
-                Logger.debug(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-            });
-        });
-        describe('#warn', () => {
-            it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
-                Logger.warn(logMsg, 'TESTCOMPONENT');
-                expect(formatLogMsgSpy.called).to.equal(true);
-                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('WARN');
-                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
-                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
-            });
-            it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
-                Logger.warn(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-                process.env.HUDDLY_LOG_LEVEL = 'INFO';
-                Logger.warn(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-                process.env.HUDDLY_LOG_LEVEL = 'NONE';
-                Logger.warn(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
-            });
-        });
-        describe('#error', () => {
-            let consoleLogSpy;
-            beforeEach(() => {
-                consoleLogSpy = sinon.spy(console, 'log');
-            });
-            afterEach(() => {
-                consoleLogSpy.restore();
-            });
-            it('should log errors by default', () => {
-                const logMsg = 'Hello World';
-                const stackTrace = 'Opppps';
-                Logger.error(logMsg, stackTrace, 'TESTCOMPONENT');
-                expect(formatLogMsgSpy.called).to.equal(true);
-                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('ERROR');
-                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
-                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
-                expect(consoleLogSpy.called).to.equal(true);
-                expect(consoleLogSpy.getCall(1).args[0]).to.equal(stackTrace);
-            });
-            it('should log errors by when HUDDLY_LOG_LEVEL is set to INFO,DEBUG,ERROR', () => {
-                let i = 0;
-                let logMsg = `Hello World ${i}`;
-                ['DEBUG', 'INFO', 'ERROR'].forEach((level: string) => {
-                    process.env.HUDDLY_LOG_LEVEL = level;
-                    Logger.error(logMsg, '');
+        describe('default logger', () => {
+            describe('#info', () => {
+                it('should should log messages when HUDDLY_LOG_LEVEL is INFO', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                    Logger.info(logMsg, 'TESTCOMPONENT');
                     expect(formatLogMsgSpy.called).to.equal(true);
-                    expect(formatLogMsgSpy.getCall(i).args[0]).to.equal('ERROR');
-                    expect(formatLogMsgSpy.getCall(i).args[1]).to.equal('Generic Component');
-                    expect(formatLogMsgSpy.getCall(i).args[2]).to.equal(logMsg);
-                    i += 1;
-                    logMsg = `Hello World ${i}`;
+                    expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
+                    expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                    expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                });
+                it('should should log messages when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.info(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(true);
+                    expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
+                    expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('Generic Component');
+                    expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                });
+                it('should not log anything when HUDDLY_LOG_LEVEL is neither INFO or DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                    Logger.info(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                    Logger.info(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
                 });
             });
-            it('should not log errors when HUDDLY_LOG_LEVEL is NONE', () => {
-                const logMsg = 'Hello World';
-                process.env.HUDDLY_LOG_LEVEL = 'NONE';
-                Logger.warn(logMsg);
-                expect(formatLogMsgSpy.called).to.equal(false);
+            describe('#debug', () => {
+                it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.debug(logMsg, 'TESTCOMPONENT');
+                    expect(formatLogMsgSpy.called).to.equal(true);
+                    expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('DEBUG');
+                    expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                    expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                });
+                it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                    Logger.debug(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                    Logger.debug(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                    Logger.debug(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                });
+            });
+            describe('#warn', () => {
+                it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.warn(logMsg, 'TESTCOMPONENT');
+                    expect(formatLogMsgSpy.called).to.equal(true);
+                    expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('WARN');
+                    expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                    expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                });
+                it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                    Logger.warn(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                    Logger.warn(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                    Logger.warn(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                });
+            });
+            describe('#error', () => {
+                let consoleLogSpy;
+                beforeEach(() => {
+                    consoleLogSpy = sinon.spy(console, 'log');
+                });
+                afterEach(() => {
+                    consoleLogSpy.restore();
+                });
+                it('should log errors by default', () => {
+                    const logMsg = 'Hello World';
+                    const stackTrace = 'Opppps';
+                    Logger.error(logMsg, stackTrace, 'TESTCOMPONENT');
+                    expect(formatLogMsgSpy.called).to.equal(true);
+                    expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('ERROR');
+                    expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                    expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                    expect(consoleLogSpy.called).to.equal(true);
+                    expect(consoleLogSpy.getCall(1).args[0]).to.equal(stackTrace);
+                });
+                it('should log errors by when HUDDLY_LOG_LEVEL is set to INFO,DEBUG,ERROR', () => {
+                    let i = 0;
+                    let logMsg = `Hello World ${i}`;
+                    ['DEBUG', 'INFO', 'ERROR'].forEach((level: string) => {
+                        process.env.HUDDLY_LOG_LEVEL = level;
+                        Logger.error(logMsg, '');
+                        expect(formatLogMsgSpy.called).to.equal(true);
+                        expect(formatLogMsgSpy.getCall(i).args[0]).to.equal('ERROR');
+                        expect(formatLogMsgSpy.getCall(i).args[1]).to.equal('Generic Component');
+                        expect(formatLogMsgSpy.getCall(i).args[2]).to.equal(logMsg);
+                        i += 1;
+                        logMsg = `Hello World ${i}`;
+                    });
+                });
+                it('should not log errors when HUDDLY_LOG_LEVEL is NONE', () => {
+                    const logMsg = 'Hello World';
+                    process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                    Logger.warn(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                });
+            });
+        });
+        describe('custom logger', () => {
+            let customLogerInstance;
+            beforeEach(() => {
+                customLogerInstance = sinon.createStubInstance(CustomLogger);
+            });
+
+            describe('#info', () => {
+                it('should call custom logger info instead of default info', () => {
+                    const logMsg = 'CUSTOM LOGGER | Hello World ';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.setLogger(customLogerInstance);
+                    Logger.info(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    expect(customLogerInstance.info.called).to.equal(true);
+                    expect(customLogerInstance.info.getCall(0).args[0]).to.equal(logMsg);
+                });
+            });
+            describe('#debug', () => {
+                it('should call custom logger info instead of default info', () => {
+                    const logMsg = 'CUSTOM LOGGER | Hello World ';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.setLogger(customLogerInstance);
+                    Logger.debug(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    expect(customLogerInstance.debug.called).to.equal(true);
+                    expect(customLogerInstance.debug.getCall(0).args[0]).to.equal(logMsg);
+                });
+            });
+            describe('#warn', () => {
+                it('should call custom logger info instead of default info', () => {
+                    const logMsg = 'CUSTOM LOGGER | Hello World ';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.setLogger(customLogerInstance);
+                    Logger.warn(logMsg);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    expect(customLogerInstance.warn.called).to.equal(true);
+                    expect(customLogerInstance.warn.getCall(0).args[0]).to.equal(logMsg);
+                });
+            });
+            describe('#error', () => {
+                it('should call custom logger info instead of default info', () => {
+                    const logMsg = 'CUSTOM LOGGER | Hello World ';
+                    const stackTrance = 'Oh ho!';
+                    process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                    Logger.setLogger(customLogerInstance);
+                    Logger.error(logMsg, stackTrance);
+                    expect(formatLogMsgSpy.called).to.equal(false);
+                    expect(customLogerInstance.error.called).to.equal(true);
+                    expect(customLogerInstance.error.getCall(0).args[0]).to.equal(logMsg);
+                    expect(customLogerInstance.error.getCall(0).args[1]).to.equal(stackTrance);
+                });
             });
         });
     });

--- a/tests/utilities/logger.spec.ts
+++ b/tests/utilities/logger.spec.ts
@@ -1,0 +1,181 @@
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import fs from 'fs';
+
+import Logger from './../../src/utilitis/logger';
+
+
+chai.should();
+chai.use(sinonChai);
+
+describe('Logger', () => {
+    afterEach(() => {
+        delete process.env.HUDDLY_LOG_LEVEL;
+        delete process.env.HUDDLY_LOG_CHANNEL;
+        delete process.env.HUDDLY_LOG_FILE;
+    });
+    describe('log levels', () => {
+        let formatLogMsgSpy;
+        beforeEach(() => {
+            formatLogMsgSpy = sinon.spy(Logger, 'formatLogMsg');
+        });
+        afterEach(() => {
+            formatLogMsgSpy.restore();
+        });
+        describe('#info', () => {
+            it('should should log messages when HUDDLY_LOG_LEVEL is INFO', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                Logger.info(logMsg, 'TESTCOMPONENT');
+                expect(formatLogMsgSpy.called).to.equal(true);
+                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
+                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+            });
+            it('should should log messages when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                Logger.info(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(true);
+                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('INFO');
+                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('Generic Component');
+                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+            });
+            it('should not log anything when HUDDLY_LOG_LEVEL is neither INFO or DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                Logger.info(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+                process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                Logger.info(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+            });
+        });
+        describe('#debug', () => {
+            it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                Logger.debug(logMsg, 'TESTCOMPONENT');
+                expect(formatLogMsgSpy.called).to.equal(true);
+                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('DEBUG');
+                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+            });
+            it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                Logger.debug(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+                process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                Logger.debug(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+                process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                Logger.debug(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+            });
+        });
+        describe('#warn', () => {
+            it('should should log messages only when HUDDLY_LOG_LEVEL is DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'DEBUG';
+                Logger.warn(logMsg, 'TESTCOMPONENT');
+                expect(formatLogMsgSpy.called).to.equal(true);
+                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('WARN');
+                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+            });
+            it('should not log anything when HUDDLY_LOG_LEVEL is not DEBUG', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'ERROR';
+                Logger.warn(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+                process.env.HUDDLY_LOG_LEVEL = 'INFO';
+                Logger.warn(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+                process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                Logger.warn(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+            });
+        });
+        describe('#error', () => {
+            let consoleLogSpy;
+            beforeEach(() => {
+                consoleLogSpy = sinon.spy(console, 'log');
+            });
+            afterEach(() => {
+                consoleLogSpy.restore();
+            });
+            it('should log errors by default', () => {
+                const logMsg = 'Hello World';
+                const stackTrace = 'Opppps';
+                Logger.error(logMsg, stackTrace, 'TESTCOMPONENT');
+                expect(formatLogMsgSpy.called).to.equal(true);
+                expect(formatLogMsgSpy.getCall(0).args[0]).to.equal('ERROR');
+                expect(formatLogMsgSpy.getCall(0).args[1]).to.equal('TESTCOMPONENT');
+                expect(formatLogMsgSpy.getCall(0).args[2]).to.equal(logMsg);
+                expect(consoleLogSpy.called).to.equal(true);
+                expect(consoleLogSpy.getCall(1).args[0]).to.equal(stackTrace);
+            });
+            it('should log errors by when HUDDLY_LOG_LEVEL is set to INFO,DEBUG,ERROR', () => {
+                let i = 0;
+                let logMsg = `Hello World ${i}`;
+                ['DEBUG', 'INFO', 'ERROR'].forEach((level: string) => {
+                    process.env.HUDDLY_LOG_LEVEL = level;
+                    Logger.error(logMsg, '');
+                    expect(formatLogMsgSpy.called).to.equal(true);
+                    expect(formatLogMsgSpy.getCall(i).args[0]).to.equal('ERROR');
+                    expect(formatLogMsgSpy.getCall(i).args[1]).to.equal('Generic Component');
+                    expect(formatLogMsgSpy.getCall(i).args[2]).to.equal(logMsg);
+                    i += 1;
+                    logMsg = `Hello World ${i}`;
+                });
+            });
+            it('should not log errors when HUDDLY_LOG_LEVEL is NONE', () => {
+                const logMsg = 'Hello World';
+                process.env.HUDDLY_LOG_LEVEL = 'NONE';
+                Logger.warn(logMsg);
+                expect(formatLogMsgSpy.called).to.equal(false);
+            });
+        });
+    });
+
+    describe('#redirectLogMsg', () => {
+        let consoleLogSpy, fsAppendFileSyncStub;
+        beforeEach(() => {
+            consoleLogSpy = sinon.spy(console, 'log');
+            fsAppendFileSyncStub = sinon.stub(fs, 'appendFileSync');
+        });
+        afterEach(() => {
+            consoleLogSpy.restore();
+            fsAppendFileSyncStub.restore();
+        });
+        it('should log to console by default', () => {
+            const logMsg = 'Hello World';
+            Logger.redirectLogMsg(logMsg);
+            expect(consoleLogSpy.called).to.equal(true);
+            expect(fsAppendFileSyncStub.called).to.equal(false);
+            expect(consoleLogSpy.getCall(0).args[0]).to.equal(logMsg);
+        });
+        it('should log to default file when HUDDLY_LOG_CHANNEL is set to FILE', () => {
+            const logMsg = 'Hello World';
+            process.env.HUDDLY_LOG_CHANNEL = 'FILE';
+            Logger.redirectLogMsg(logMsg);
+            expect(fsAppendFileSyncStub.called).to.equal(true);
+            expect(fsAppendFileSyncStub.getCall(0).args[0]).to.equal('huddlysdk.log');
+            expect(fsAppendFileSyncStub.getCall(0).args[1]).to.equal(`${logMsg}\n`);
+        });
+        it('should log to custom file when HUDDLY_LOG_CHANNEL is set to FILE', () => {
+            const logMsg = 'Hello World';
+            process.env.HUDDLY_LOG_CHANNEL = 'FILE';
+            process.env.HUDDLY_LOG_FILE = 'mylog.log';
+            Logger.redirectLogMsg(logMsg);
+            expect(fsAppendFileSyncStub.called).to.equal(true);
+            expect(fsAppendFileSyncStub.getCall(0).args[0]).to.equal('mylog.log');
+            expect(fsAppendFileSyncStub.getCall(0).args[1]).to.equal(`${logMsg}\n`);
+        });
+    });
+    /* describe('#formatDate');
+    describe('#getTime');
+    describe('#formatLogMsg'); */
+});


### PR DESCRIPTION
- Update logger class to have static methods for info, debug, warn and
error
- On all sdk class instances, call the static methods of the logger
instead of passing the logger instances around
- Update the logger to determine verbosity (log level) based on environment variable `HUDDLY_LOG_LEVEL`
- Add support for configuring the log channel using the env variable `HUDDLY_LOG_CHANNEL` in combination with `HUDDLY_LOG_FILE`. Currently you can redirect the logs onto console log or to a specific log file.
- Add support for setting a custom logger to the SDK from consumer side