### PR TITLE
feat(Ace): device info should be assign to the ace object

### DIFF
--- a/src/components/device/ace.ts
+++ b/src/components/device/ace.ts
@@ -76,6 +76,7 @@ export default class Ace implements IDeviceManager, IUVCControls {
     this.transport = transport;
     this.locksmith = new Locksmith();
     this.discoveryEmitter = cameraDiscoveryEmitter;
+    Object.assign(this, wsdDevice);
   }
 
   async initialize(developmentMode: boolean = false): Promise<void> {


### PR DESCRIPTION
Needed to make information such as productId accessible from the ace device object