### PR TITLE
Ace upgrade filebuffer support

### DIFF
--- a/src/interfaces/IUpgradeOpts.ts
+++ b/src/interfaces/IUpgradeOpts.ts
@@ -15,12 +15,6 @@ export default interface UpgradeOpts {
   file: Buffer;
 
   /**
-   * Path to the cpio file. The ace upgrader cannot be completed by sending in a buffer from fs.readFileSync,
-   * so make sure you just provide the file path instead
-   */
-  cpioFilePath?: string;
-
-  /**
    * A timeout number which restricts the upgrader on
    * how long it should wait until the camera comes back
    * up after being rebooted during the upgrade process.

--- a/src/utilitis/bufferStream.ts
+++ b/src/utilitis/bufferStream.ts
@@ -1,0 +1,63 @@
+import { Readable } from 'stream';
+
+export default class BufferStream extends Readable {
+  /**
+   * Copy of the original buffer to be converted into a readable stream
+   * @type Buffer
+   * @memberof BufferStream
+   */
+  source: Buffer;
+
+  /**
+   * Offset number to keep track of which portion of the source buffer is
+   * currently being pushed onto the internal stream buffer during read actions
+   * @type number
+   * @memberof BufferStream
+   */
+  offset: number;
+
+  /**
+   * Length of the original buffer
+   * @type number
+   * @memberof BufferStream
+   */
+  length: number;
+
+  /**
+   * Turns the given source Buffer into a Readable stream.
+   * @param  {Buffer} source
+   */
+  constructor(source: Buffer) {
+    super();
+
+    this.source = source;
+
+    this.offset = 0;
+    this.length = source.length;
+
+    // When the stream has ended, try to clean up the memory references.
+    this.on('end', this.destroy);
+  }
+
+  /**
+   * Clean up variable references once the stream has been ended.
+   */
+  destroy(): void {
+    this.source = this.offset = this.length = undefined;
+  }
+
+  /**
+   * Read chunks from the source buffer into the underlying stream buffer.
+   * @param  {number} size The size of the chunk to read from buffer into the stream.
+   */
+  _read(size: number): void {
+    if (this.offset < this.length) {
+      this.push(this.source.slice(this.offset, this.offset + size));
+      this.offset += size;
+    }
+
+    if (this.offset >= this.length) {
+      this.push(undefined);
+    }
+  }
+}

--- a/tests/components/upgrader/aceUpgrader.spec.ts
+++ b/tests/components/upgrader/aceUpgrader.spec.ts
@@ -146,11 +146,11 @@ describe('AceUpgrader', () => {
       expect(spy.getCall(0).args[0].status).to.equal('Starting upgrade');
       expect(spy.getCall(0).args[0].progress).to.equal(0);
       // Flash completed
-      expect(spy.getCall(1).args[0].progress).to.equal(40);
+      expect(spy.getCall(1).args[0].progress).to.equal(15);
 
       // Reboot step
       expect(spy.getCall(2).args[0].status).to.equal('Rebooting camera');
-      expect(spy.getCall(2).args[0].progress).to.equal(40);
+      expect(spy.getCall(2).args[0].progress).to.equal(31);
     });
 
     it('should check version state, version, commit and finish upgrade', async () => {
@@ -171,11 +171,11 @@ describe('AceUpgrader', () => {
             expect(spy.callCount).to.equal(6);
 
             // Reboot step completed
-            expect(spy.getCall(3).args[0].progress).to.equal(60);
+            expect(spy.getCall(3).args[0].progress).to.equal(90);
 
             // Commit step started
             expect(spy.getCall(4).args[0].status).to.equal('Verifying new software');
-            expect(spy.getCall(4).args[0].progress).to.equal(60);
+            expect(spy.getCall(4).args[0].progress).to.equal(95);
 
             expect(commitStub.called).to.equal(true);
 

--- a/tests/utilities/bufferStream.spec.ts
+++ b/tests/utilities/bufferStream.spec.ts
@@ -1,0 +1,69 @@
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import BufferStream from './../../src/utilitis/bufferStream';
+
+chai.should();
+chai.use(sinonChai);
+
+describe('BufferStream', () => {
+  describe('#constructor', () => {
+    let destroySpy;
+    beforeEach(() => {
+      destroySpy = sinon.spy(BufferStream.prototype, 'destroy');
+    });
+    afterEach(() => {
+      destroySpy?.restore();
+    });
+
+    it('should initialize attributes', () => {
+      const dummyBuffer = Buffer.alloc(10);
+      const bufferStream = new BufferStream(dummyBuffer);
+      expect(bufferStream.length).to.equal(dummyBuffer.length);
+      expect(bufferStream.offset).to.equal(0);
+      expect(bufferStream.source).to.deep.equal(dummyBuffer);
+    });
+
+    it('should destroy  buffer stream on "end" event from super class', () => {
+      const bufferStream = new BufferStream(Buffer.alloc(0));
+      bufferStream.emit('end');
+      expect(destroySpy).to.have.been.called;
+    });
+  });
+
+  describe('#destroy', () => {
+    it('should reset attributes', () => {
+      const bufferStream = new BufferStream(Buffer.alloc(0));
+      bufferStream.destroy();
+      expect(bufferStream.source).to.be.undefined;
+      expect(bufferStream.length).to.be.undefined;
+      expect(bufferStream.offset).to.be.undefined;
+    });
+  });
+
+  describe('#read', () => {
+    let pushSpy;
+    beforeEach(() => {
+      pushSpy = sinon.spy(BufferStream.prototype, 'push');
+    });
+    afterEach(() => {
+      pushSpy?.restore();
+    });
+
+    it('should push chunks of bytes from the original buffer into the stream', () => {
+      const sourceBuffer = Buffer.from('HelloWorld');
+      const bufferStream = new BufferStream(sourceBuffer);
+      bufferStream._read(5);
+      expect(pushSpy.getCall(0).args[0]).to.deep.equal(Buffer.from('Hello'));
+      bufferStream._read(5);
+      expect(pushSpy.getCall(1).args[0]).to.deep.equal(Buffer.from('World'));
+    });
+
+    it('should push null/undefined at the end of the buffer to signalize the end of the read stream', () => {
+      const sourceBuffer = Buffer.from('Hello');
+      const bufferStream = new BufferStream(sourceBuffer);
+      bufferStream._read(100);
+      expect(pushSpy.getCall(1).args[0]).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
- Fix ace upgrader to accept a filer buffer instead of file path
- Fix ace upgrade progress status events (better distribution of the percentages on each stage)
- Starting a nodejs time interval emitting progress events whilst the camera is booting up