### PR TITLE
fix: Update L1 pid from 3E9 to 0x3E9

### DIFF
--- a/src/components/device/factory.ts
+++ b/src/components/device/factory.ts
@@ -16,7 +16,7 @@ export const HUDDLY_GO_PID = 0x11;
 export const HUDDLY_BOXFISH_PID = 0x21;
 export const HUDDLY_CLOWNFISH_PID = 0x31;
 export const HUDDLY_DWARFFISH_PID = 0x51;
-export const HUDDLY_L1_PID = 3E9; // 1001 for L1/Ace
+export const HUDDLY_L1_PID = 0x3E9; // 1001 for L1/Ace
 
 export function createFactory(): IDeviceFactory {
   return DeviceFactory;


### PR DESCRIPTION
This should reflect the indeded decimal value which is 1001 for L1. Output:

```
{
  name: 'L1',
  mac: '90:E2:FC:90:12:EC',
  ipv4: '169.254.98.175',
  serialNumber: '12101A0029',
  modelName: '810-00011-MBLK',
  manufacturer: 'Huddly',
  productId: 1001, // ,<---------------------- UPDATED INFORMATION
  version: '1.2.5-4035.13+sha.bf526c3',
  uptime: 32.26,
  slot: 'B'
}
```