### PR TITLE
bugfix: Avoid discovery hang for BASE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,8 +224,10 @@ class HuddlySdk extends EventEmitter {
                 this.emitter.emit(CameraEvents.ATTACH, cameraManager);
                 resolve();
               } catch (e) {
-                Logger.error('Could not get device!', e, HuddlySdk.name);
-                this.emitter.emit(CameraEvents.ERROR, new AttachError('No transport supported', ErrorCodes.NO_TRANSPORT));
+                const errorMsg: string = `No transport implementation supported for ${JSON.stringify(d)}`;
+                Logger.warn(errorMsg, HuddlySdk.name);
+                this.emitter.emit(CameraEvents.ERROR, new AttachError(errorMsg, ErrorCodes.NO_TRANSPORT));
+                resolve();
               }
             })
         );

--- a/tests/sdk.spec.ts
+++ b/tests/sdk.spec.ts
@@ -87,6 +87,11 @@ describe('HuddlySDK', () => {
       productId: 0x21,
       serialNumber: deviceSerial
     };
+    const dummyBase = {
+      productId: 0xBA5E,
+      serialNumber: '1241234541234'
+    };
+
     let huddlygoInitStub;
     let boxfishInitStub;
     let discoveryEmitter;
@@ -217,8 +222,28 @@ describe('HuddlySDK', () => {
         });
         discoveryEmitter.emit('ATTACH', dummyIQ);
       });
+      it('should emit error and resolve if BASE is discovered', (done) => {
+        initSdk();
+        otherEmitter.on('ERROR', (e) => {
+          expect(e).to.be.instanceof(Error);
+          expect(e.message).to.equal(`No transport implementation supported for {"productId":47710,"serialNumber":"1241234541234"}`);
+          done();
+        });
+        discoveryEmitter.emit('ATTACH', dummyBase);
+      });
     });
-
+    describe('combined', () => {
+      it('should should resolve IQ when non supported Huddly device gets discovered first', (done) => {
+        initSdk();
+        otherEmitter.on('ATTACH', (d) => {
+          expect(d).to.be.instanceof(Boxfish);
+          expect(d.serialNumber).to.equals(deviceSerial);
+          done();
+        });
+        discoveryEmitter.emit('ATTACH', dummyBase);
+        discoveryEmitter.emit('ATTACH', dummyIQ);
+      });
+    });
   });
 
   describe('#init', () => {


### PR DESCRIPTION
The try...catch block inside a promise on sdk#setupDeviceDiscoveryListeners for the ATTACH event should be resolved for both cases when the try succeeds or the catch is invoked. This scenario was initiation when a BASE device was discovered and no transport implementation is supported for it so we ended up in the catch block and were not able to complete the execution of the block due to the promise not being marked as completed. Fix was to just add `resolve()` at the end of the catch block.