### PR TITLE
refactor: Export huddly vendor id on factory.ts

### DIFF
--- a/src/components/device/factory.ts
+++ b/src/components/device/factory.ts
@@ -12,6 +12,7 @@ import Clownfish from './clownfish';
 import Ace from './ace';
 import { EventEmitter } from 'events';
 
+export const HUDDLY_VID = 0x2bd9;
 export const HUDDLY_GO_PID = 0x11;
 export const HUDDLY_BOXFISH_PID = 0x21;
 export const HUDDLY_CLOWNFISH_PID = 0x31;

--- a/src/components/device/factory.ts
+++ b/src/components/device/factory.ts
@@ -18,6 +18,7 @@ export const HUDDLY_BOXFISH_PID = 0x21;
 export const HUDDLY_CLOWNFISH_PID = 0x31;
 export const HUDDLY_DWARFFISH_PID = 0x51;
 export const HUDDLY_L1_PID = 0x3E9; // 1001 for L1/Ace
+export const HUDDLY_BASE_PID = 0xBA5E;
 
 export function createFactory(): IDeviceFactory {
   return DeviceFactory;


### PR DESCRIPTION
This will be imported by device-api-* instead of hardcoding the value in several places