### PR TITLE
chore: update @huddly/camera-switch-proto@0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -410,9 +410,9 @@
       }
     },
     "@huddly/camera-switch-proto": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@huddly/camera-switch-proto/-/camera-switch-proto-0.0.3.tgz",
-      "integrity": "sha512-JAOC3y+4bsG1FqdkuEF1ZKD+jrx4wBBbrXDOeaz10QW0ZOkN7FzVVTx0sBLCr65sf2cp3MWShAPTPrTmZKkKPg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@huddly/camera-switch-proto/-/camera-switch-proto-0.0.4.tgz",
+      "integrity": "sha512-ZCTRNTzMkDhC7LKWWwHNW8/+PB/uakDlN4DnNQbNXiY+vU0CAY3deCZciyxG+e9R2n2KEPONoUOHV3iSNTfFSw==",
       "requires": {
         "grpc-tools": "^1.11.2",
         "grpc_tools_node_protoc_ts": "^5.2.2",
@@ -1151,6 +1151,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.3",
@@ -3215,6 +3225,13 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5178,6 +5195,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7934,7 +7958,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.2",
     "@huddly/camera-proto": "^1.0.8",
-    "@huddly/camera-switch-proto": "0.0.3",
+    "@huddly/camera-switch-proto": "^0.0.4",
     "cpio-stream": "^1.4.1",
     "google-protobuf": "^3.17.3",
     "jszip": "3.2.2",

--- a/src/components/service/cameraSwitchService.ts
+++ b/src/components/service/cameraSwitchService.ts
@@ -93,25 +93,6 @@ export default class CameraSwitchService implements IHuddlyService {
   }
 
   /**
-   * Helper function for properly formatting the mac address being sent over to the
-   * service grpc server
-   * @param {mac} Mac address in string fromat
-   * @returns Mac address in a format that is satisfactory for the service when sending it
-   * over gprc
-   */
-  formatMacAddress(mac: string): string {
-    if (mac.indexOf(':') == -1 && mac.indexOf('-') == -1) {
-      throw new Error(
-        `Format Error! The folloing mac address is not valid: ${mac}. Use - or : as delimiters`
-      );
-    }
-    if (mac.indexOf(':') > -1) {
-      return mac.split(':').join('-');
-    }
-    return mac;
-  }
-
-  /**
    * Helper function for calling a setter command on the service grpc server. Using the
    * parameter "action" to determine which specific setter to invoke.
    * @param  {ServiceCameraActions} action Determine which setter should be called on
@@ -123,7 +104,6 @@ export default class CameraSwitchService implements IHuddlyService {
    */
   serviceCameraSetter(action: ServiceCameraActions, camInfo: CameraInfo): Promise<void> {
     const serviceCamInfo: switchservice.CameraInfo = new switchservice.CameraInfo();
-    serviceCamInfo.setMac(this.formatMacAddress(camInfo.mac));
     serviceCamInfo.setName(camInfo.name);
     serviceCamInfo.setIp(camInfo.ip);
     const setterActionStr: string = Object.keys(ServiceCameraActions).find(

--- a/src/interfaces/ICameraSwitchModels.ts
+++ b/src/interfaces/ICameraSwitchModels.ts
@@ -2,7 +2,6 @@
  * @ignore
  */
 export interface CameraInfo {
-  mac?: string;
   name?: string;
   ip?: string;
 }

--- a/tests/components/service/cameraSwitchService.spec.ts
+++ b/tests/components/service/cameraSwitchService.spec.ts
@@ -62,48 +62,28 @@ describe('CameraSwitchService', () => {
     });
   });
 
-  describe('#formatMacAddress', () => {
-    it('should format FF:FF:FF to FF-FF-FF', () => {
-      const expected = 'FF-FF-FF';
-      const got = service.formatMacAddress('FF:FF:FF');
-      expect(expected).to.equal(got);
-    });
-    it('should keep same mac address format is format is correct', () => {
-      const expected = 'FF-FF-FF';
-      const got = service.formatMacAddress(expected);
-      expect(expected).to.equal(got);
-    });
-    it('should throw error when mac address has wrong format', () => {
-      const fn = (macAddr) => { service.formatMacAddress(macAddr); };
-      const malFormedMacs = ['FF,FF,FF,FF', 'FF/FF/FF/FF', '', 'FFFFFFFF'];
-      malFormedMacs.forEach((macAddr) => {
-        expect(() => fn(macAddr)).to.throw(`Format Error! The folloing mac address is not valid: ${macAddr}. Use - or : as delimiters`);
-      });
-    });
-  });
-
   describe('#serviceCameraSetter', () => {
     describe('onGrpcSuccess', () => {
       it('should call setActiveCamera and resolve on callback', () => {
         (service.grpcClient.setActiveCamera as any).yields(undefined);
-        const promise = service.serviceCameraSetter(ServiceCameraActions.ACTIVE, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        const promise = service.serviceCameraSetter(ServiceCameraActions.ACTIVE, { name: 'L1', ip: '1.2.3.4' });
         return expect(promise).to.be.fulfilled;
       });
       it('should call setDefaultCamera and resolve on callback', () => {
         (service.grpcClient.setDefaultCamera as any).yields(undefined);
-        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { name: 'L1', ip: '1.2.3.4' });
         return expect(promise).to.be.fulfilled;
       });
     });
     describe('onGrpcFailure', () => {
       it('should reject with the error received from grpc call', () => {
         (service.grpcClient.setDefaultCamera as any).yields({details: 'Something went wrong', stack: ''});
-        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+        const promise = service.serviceCameraSetter(ServiceCameraActions.DEFAULT, { name: 'L1', ip: '1.2.3.4' });
         return expect(promise).to.eventually.be.rejectedWith('Something went wrong');
       });
     });
     it('should throw error when passing wrong action', () => {
-      const promise = service.serviceCameraSetter(-1, { mac: 'FF-FF', name: 'L1', ip: '1.2.3.4' });
+      const promise = service.serviceCameraSetter(-1, { name: 'L1', ip: '1.2.3.4' });
       return expect(promise).to.eventually.be.rejectedWith('Unknown service camera action: undefined');
     });
   });
@@ -111,7 +91,6 @@ describe('CameraSwitchService', () => {
   describe('#serviceCameraGetter', () => {
     const serviceCamInfo: switchservice.CameraInfo = new switchservice.CameraInfo();
     before(() => {
-      serviceCamInfo.setMac('FFFFFFF');
       serviceCamInfo.setName('L1');
       serviceCamInfo.setIp('1.2.3');
     });


### PR DESCRIPTION
This version removes the "mac" field of the proto definition which is
not required anymore by the windows service