### PR TITLE
chore(package.json): bump @Huddly/camera-proto -> 1.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -430,9 +430,9 @@
       }
     },
     "@huddly/camera-proto": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@huddly/camera-proto/-/camera-proto-1.0.8.tgz",
-      "integrity": "sha512-M6AkVAQYWvbCt9pqzbKdISNQPe1DlzQwII1tRz6sz8m+mx4D+kGuQiCTCpURMOABPltsmj3CQ4IW00stJYRd3A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@huddly/camera-proto/-/camera-proto-1.0.9.tgz",
+      "integrity": "sha512-tH4FF5JAdkqOqFz9d41lvTWhrqiRFPvI1Cgt43Cm+/X8LtEUJ94EZo2h1NnA9q7LJ4FSj67kyKlcW0E3twuWDw==",
       "requires": {
         "grpc-tools": "^1.11.2",
         "grpc_tools_node_protoc_ts": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.3.2",
-    "@huddly/camera-proto": "^1.0.8",
+    "@huddly/camera-proto": "^1.0.9",
     "@huddly/camera-switch-proto": "^0.0.4",
     "cpio-stream": "^1.4.1",
     "google-protobuf": "^3.17.3",


### PR DESCRIPTION
This version includes the new endpoint ControlSetting in the proto definition, which enables things
like storing ptz settings