### PR TITLE
fix(ipdetector.ts): _stopDetections should invoke setCnnFeature with the correct mode

### DIFF
--- a/src/components/ipDetector.ts
+++ b/src/components/ipDetector.ts
@@ -103,7 +103,7 @@ export default class IpDetector extends EventEmitter implements IDetector {
     return new Promise((resolve, reject) => {
       const cnnFeature = new huddly.CnnFeature();
       cnnFeature.setFeature(huddly.Feature.DETECTOR);
-      cnnFeature.setMode(huddly.Mode.START);
+      cnnFeature.setMode(huddly.Mode.STOP);
       this._deviceManager.grpcClient.setCnnFeature(
         cnnFeature,
         (err, status: huddly.DeviceStatus) => {

--- a/tests/components/ipDetector.spec.ts
+++ b/tests/components/ipDetector.spec.ts
@@ -106,9 +106,9 @@ describe('IpDetector', () => {
           ipDetector = new IpDetector(deviceManager, {});
           await ipDetector.init();
           await ipDetector.destroy();
-          const arg = setCnnFeatureSpy.firstCall.args[0];
+          const arg = setCnnFeatureSpy.secondCall.args[0];
           expect(arg.getFeature()).to.equal(huddly.Feature.DETECTOR);
-          expect(arg.getMode()).to.equal(huddly.Mode.START);
+          expect(arg.getMode()).to.equal(huddly.Mode.STOP);
         });
       });
       describe('on DOWS set', () => {


### PR DESCRIPTION
Previsouly the setCnnFeature was invoked with the START mode instead of
STOP as it should be.