### PR TITLE
Users/eskil/raw detections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "@huddly/camera-proto": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@huddly/camera-proto/-/camera-proto-1.0.9.tgz",
-      "integrity": "sha512-tH4FF5JAdkqOqFz9d41lvTWhrqiRFPvI1Cgt43Cm+/X8LtEUJ94EZo2h1NnA9q7LJ4FSj67kyKlcW0E3twuWDw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@huddly/camera-proto/-/camera-proto-1.0.11.tgz",
+      "integrity": "sha512-KTaCZ0s9oTKrZ23YREqSC8HAaNLjmVOxJUbdt0j+5CIpj6ZWVglZh8whplOJY+/4+c1oYcx+hirpl8loSQiJVA==",
       "requires": {
         "grpc-tools": "^1.11.2",
         "grpc_tools_node_protoc_ts": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.3.2",
-    "@huddly/camera-proto": "1.0.9",
+    "@huddly/camera-proto": "1.0.11",
     "@huddly/camera-switch-proto": "0.0.6",
     "cpio-stream": "^1.4.1",
     "google-protobuf": "^3.17.3",

--- a/src/interfaces/IDetectorOpts.ts
+++ b/src/interfaces/IDetectorOpts.ts
@@ -40,6 +40,14 @@ export default interface DetectorOpts {
    * @memberof DetectorOpts
    */
   DOWS?: boolean;
+
+  /**
+   * When set to true, the `Detector` will emit a
+   * 'RAW_DETECTIONS' event with raw detection data
+   * for every 'DETECTIONS' event.
+   */
+  includeRawDetections?: boolean;
+
 }
 
 export { DetectionConvertion };

--- a/src/utilitis/throttle.ts
+++ b/src/utilitis/throttle.ts
@@ -1,0 +1,12 @@
+export default function throttle(callback: Function, limit: number): Function {
+  let waiting = false;
+  return function () {
+    if (!waiting) {
+      callback.apply(this, arguments);
+      waiting = true;
+      setTimeout(function () {
+        waiting = false;
+      }, limit);
+    }
+  };
+}

--- a/tests/components/detector.spec.ts
+++ b/tests/components/detector.spec.ts
@@ -17,15 +17,17 @@ describe('Detector', () => {
     detector = new Detector(deviceManager);
   });
 
-  describe('#validateOptions', () => {
+  describe('#_validateOptions', () => {
     it('should update old options with new options', () => {
       expect(detector._options.convertDetections).to.equals(DetectionConvertion.RELATIVE);
       expect(detector._options.DOWS).to.equals(false);
+      expect(detector._options.includeRawDetections).to.equal(false);
       const newOpts: DetectorOpts = {
         DOWS: true,
         convertDetections: DetectionConvertion.FRAMING,
+        includeRawDetections: true,
       };
-      detector.validateOptions(newOpts);
+      detector._validateOptions(newOpts);
       expect(detector._options).to.deep.equals(newOpts);
     });
   });
@@ -125,6 +127,7 @@ describe('Detector', () => {
     const newOpts: DetectorOpts = {
       DOWS: true,
       convertDetections: DetectionConvertion.FRAMING,
+      includeRawDetections: true,
     };
     beforeEach(() => {
       teardownStub = sinon.stub(detector, 'teardownDetectorSubscriptions').resolves();
@@ -136,7 +139,7 @@ describe('Detector', () => {
     });
 
     it('should validate new options', async () => {
-      const validateOptionsSpy = sinon.spy(detector, 'validateOptions');
+      const validateOptionsSpy = sinon.spy(detector, '_validateOptions');
       await detector.updateOpts(newOpts);
       expect(validateOptionsSpy.called).to.equals(true);
       expect(validateOptionsSpy.getCall(0).args[0]).to.deep.equals(newOpts);
@@ -147,6 +150,7 @@ describe('Detector', () => {
       expect(teardownStub.called).to.equals(true);
       expect(detector._detectorInitialized).to.equals(false);
       expect(initStub.called).to.equals(true);
+      expect(detector._options.includeRawDetections).to.equal(true);
     });
   });
 

--- a/tests/components/ipDetector.spec.ts
+++ b/tests/components/ipDetector.spec.ts
@@ -5,8 +5,10 @@ import IpDetector from '../../src/components/ipDetector';
 import IIPDeviceManager from '../../src/interfaces/iIpDeviceManager';
 import DeviceManagerMock from '../mocks/ipdevicemanager.mock';
 import CameraEvents from '../../src/utilitis/events';
+import Logger from './../../src/utilitis/logger';
 import * as huddly from '@huddly/camera-proto/lib/api/huddly_pb';
 import DetectorOpts, { DetectionConvertion } from './../../src/interfaces/IDetectorOpts';
+import { utils } from 'mocha';
 
 chai.should();
 chai.use(sinonChai);
@@ -31,6 +33,118 @@ describe('IpDetector', () => {
       ipDetector.destroy();
     });
     describe('on detector not initialized', () => {
+      describe('on grpcServer responding with duplicate detections', () => {
+        let getDetectionsStub;
+        const detectionsDummy = new huddly.Detections();
+        detectionsDummy.setTimestamp(100.0);
+        beforeEach(() => {
+          getDetectionsStub = sinon
+            .stub(deviceManager.grpcClient, 'getDetections')
+            .callsArgWith(1, undefined, detectionsDummy);
+        });
+        afterEach(() => {
+          getDetectionsStub.restore();
+        });
+        it('should not emit stale detections', async () => {
+          ipDetector = new IpDetector(deviceManager, {});
+          const cb = sinon.spy();
+          ipDetector.on(CameraEvents.DETECTIONS, cb);
+          await ipDetector.init();
+          clock.tick(ipDetector._UPDATE_INTERVAL);
+          await clock.next();
+          expect(getDetectionsStub.callCount).to.equal(2);
+          expect(cb.callCount).to.equal(1);
+        });
+      });
+
+      describe('on grpcServer responding with invalid detections', () => {
+        let getDetectionsStub;
+        let warnStub;
+        const detectionsDummy = new huddly.Detections();
+        // If timestamp < 0 it means that IMX has not received any detections,
+        // likely due to detector not being started / AZ not on / camera not streaming
+        detectionsDummy.setTimestamp(-1.0);
+        beforeEach(() => {
+          warnStub = sinon.stub(Logger, 'warn');
+          getDetectionsStub = sinon
+            .stub(deviceManager.grpcClient, 'getDetections')
+            .callsArgWith(1, undefined, detectionsDummy);
+        });
+        afterEach(() => {
+          getDetectionsStub.restore();
+          warnStub.restore();
+        });
+        it('should log a warning', async () => {
+          ipDetector = new IpDetector(deviceManager, {});
+          await ipDetector.init();
+          clock.tick(ipDetector._UPDATE_INTERVAL);
+          await clock.next();
+          expect(warnStub).to.have.been.called;
+        });
+        it('should not emit invalid detections', async () => {
+          ipDetector = new IpDetector(deviceManager, {});
+          const cb = sinon.spy();
+          ipDetector.on(CameraEvents.DETECTIONS, cb);
+          await ipDetector.init();
+          clock.tick(ipDetector._UPDATE_INTERVAL);
+          await clock.next();
+          expect(getDetectionsStub.callCount).to.equal(2);
+          expect(cb.callCount).to.equal(0);
+        });
+      });
+
+      describe('on grpcServer responding with distinct detections', () => {
+        let getDetectionsStub;
+        const firstDetectionsDummy = new huddly.Detections();
+        firstDetectionsDummy.setTimestamp(100.0);
+        const secondDetectionsDummy = new huddly.Detections();
+        secondDetectionsDummy.setTimestamp(150.0);
+        beforeEach(() => {
+          getDetectionsStub = sinon
+            .stub(deviceManager.grpcClient, 'getDetections')
+            .onFirstCall()
+            .callsArgWith(1, undefined, firstDetectionsDummy)
+            .onSecondCall()
+            .callsArgWith(1, undefined, secondDetectionsDummy);
+        });
+        afterEach(() => {
+          getDetectionsStub.restore();
+        });
+        it('should emit all distinct detections', async () => {
+          ipDetector = new IpDetector(deviceManager, {});
+          const cb = sinon.spy();
+          ipDetector.on(CameraEvents.DETECTIONS, cb);
+          await ipDetector.init();
+          clock.tick(ipDetector._UPDATE_INTERVAL);
+          await clock.next();
+          expect(getDetectionsStub.callCount).to.equal(2);
+          expect(cb.callCount).to.equal(2);
+        });
+      });
+
+      describe('on querying old L1 versions where timestamp is not set', () => {
+        let getDetectionsStub;
+        const detectionsDummy = new huddly.Detections();
+        beforeEach(() => {
+          getDetectionsStub = sinon
+            .stub(deviceManager.grpcClient, 'getDetections')
+            .callsArgWith(1, undefined, detectionsDummy);
+        });
+        afterEach(() => {
+          getDetectionsStub.restore();
+        });
+        it('should emit all DETECTIONS it receives', async () => {
+          ipDetector = new IpDetector(deviceManager, {});
+          const cb = sinon.spy();
+          ipDetector.on(CameraEvents.DETECTIONS, cb);
+          await ipDetector.init();
+          clock.tick(ipDetector._UPDATE_INTERVAL * 2);
+          await clock.next();
+          expect(getDetectionsStub.callCount).to.equals(3);
+          expect(cb.callCount).to.equals(3);
+        });
+      });
+
       describe('on includeRawDetections is true', () => {
         it('should emit both DETECTIONS and RAWDETECTIONS at initialization', async () => {
           ipDetector = new IpDetector(deviceManager, { includeRawDetections: true });
@@ -43,8 +157,8 @@ describe('IpDetector', () => {
           await clock.next();
           expect(cb.called).to.equal(true);
           expect(rawCb.called).to.equal(true);
-        })
-      })
+        });
+      });
       describe('on includeRawDetections is false', () => {
         it('should only emit DETECTIONS', async () => {
           ipDetector = new IpDetector(deviceManager, { includeRawDetections: false });
@@ -57,19 +171,10 @@ describe('IpDetector', () => {
           await clock.next();
           expect(cb.called).to.equal(true);
           expect(rawCb.called).to.equal(false);
-        })
+        });
       });
 
       describe('on DOWS not set', () => {
-        it('should emit DETECTIONS event at initialization and every update interval', async () => {
-          ipDetector = new IpDetector(deviceManager, {});
-          const cb = sinon.spy();
-          ipDetector.on(CameraEvents.DETECTIONS, cb);
-          await ipDetector.init();
-          clock.tick(ipDetector._UPDATE_INTERVAL * 2);
-          await clock.next();
-          expect(cb.callCount).to.equals(3);
-        });
         it('should call setCnnFeature with correct arg', async () => {
           ipDetector = new IpDetector(deviceManager, {});
           await ipDetector.init();
@@ -78,15 +183,6 @@ describe('IpDetector', () => {
           expect(arg.getMode()).to.equal(huddly.Mode.START);
         });
         describe('On DOWS set', () => {
-          it('should emit DETECTIONS event at initialization and every update interval', async () => {
-            ipDetector = new IpDetector(deviceManager, { DOWS: true });
-            const cb = sinon.spy();
-            ipDetector.on(CameraEvents.DETECTIONS, cb);
-            await ipDetector.init();
-            clock.tick(ipDetector._UPDATE_INTERVAL * 2);
-            await clock.next();
-            expect(cb.callCount).to.equals(3);
-          });
           it('should not call setCnnFeature', async () => {
             ipDetector = new IpDetector(deviceManager, { DOWS: true });
             await ipDetector.init();
@@ -184,6 +280,6 @@ describe('IpDetector', () => {
       ipDetector = new IpDetector(deviceManager, {});
       await ipDetector.updateOpts(newOpts);
       expect(ipDetector._options).to.deep.equals(newOpts);
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
In some cases consumers are interested in raw detections data (for instance when sending feedback from the app).

I've introduced an optional flag which makes the detectors emit this data in addition to processed detections.

Also included is a fix where the ipDetector now filters out duplicate detections, and will only emit distinct ones.