### PR TITLE
fix: temporary workaround for not emitting dummy rawDetections

### DIFF
--- a/src/components/ipDetector.ts
+++ b/src/components/ipDetector.ts
@@ -99,6 +99,10 @@ export default class IpDetector extends EventEmitter implements IDetector {
       );
       this.emit(CameraEvents.DETECTIONS, convertedDetections);
       if (this._options.includeRawDetections) {
+        // Workaround until this is fixed camera side
+        if (rawDetections.detectionsList[0] && rawDetections.detectionsList[0].label === 'NULL') {
+          rawDetections.detectionsList = [];
+        }
         this.emit(CameraEvents.RAW_DETECTIONS, rawDetections);
       }
     };


### PR DESCRIPTION
For ...reasons, falcon-app will send out a message with 
`detectionsList: [ { id: 0, label: "NULL", ... } ]`
For situations where the camera does not detect any people on the frame.

With the previous implementation, this would be emitted in the RAW_DETECTIONS event. This little thing fixes that, but obviously this should be fixed camera side in the long run.