### PR TITLE
depend on huddly fork of cpio-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@grpc/grpc-js": "^1.3.2",
     "@huddly/camera-proto": "1.0.11",
     "@huddly/camera-switch-proto": "0.0.6",
-    "cpio-stream": "^1.4.1",
+    "cpio-stream": "git+ssh://git@github.com/Huddly/cpio-stream.git",
     "google-protobuf": "^3.17.3",
     "jszip": "3.2.2",
     "msgpack-lite": "~0.1.26",


### PR DESCRIPTION
 that fixes a bug in the officia npm package which makes it incompatible with newer versions of js

This is perhaps not the right way to do it .. i have no clue.. 