### PR TITLE
Remove legacy async filetransfer code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@grpc/grpc-js": "^1.3.2",
         "@huddly/camera-proto": "1.0.11",
         "@huddly/camera-switch-proto": "0.0.6",
-        "@huddly/sdk-interfaces": "^0.1.2",
+        "@huddly/sdk-interfaces": "^0.2.0",
         "chalk": "^4.1.2",
         "cpio-stream": "^1.4.3",
         "google-protobuf": "^3.17.3",
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@huddly/sdk-interfaces": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@huddly/sdk-interfaces/-/sdk-interfaces-0.1.2.tgz",
-      "integrity": "sha512-pGT7y/mWYlu35e28nci7eBz/g1AL4JeynlEifO14vT8RytBFuiIBXX8+VAQ9MEAMpBzyO5NZRiz581GSSYe7uw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@huddly/sdk-interfaces/-/sdk-interfaces-0.2.0.tgz",
+      "integrity": "sha512-r7t8eQ4OEU4gO46tqxoC4S26MjVte8HhtwIYvtwj2BLrp0XO2vYHhSAqtguI3zjegmSDpX5Kt3TxMaEo0ZvBcA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -6883,9 +6883,9 @@
       }
     },
     "@huddly/sdk-interfaces": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@huddly/sdk-interfaces/-/sdk-interfaces-0.1.2.tgz",
-      "integrity": "sha512-pGT7y/mWYlu35e28nci7eBz/g1AL4JeynlEifO14vT8RytBFuiIBXX8+VAQ9MEAMpBzyO5NZRiz581GSSYe7uw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@huddly/sdk-interfaces/-/sdk-interfaces-0.2.0.tgz",
+      "integrity": "sha512-r7t8eQ4OEU4gO46tqxoC4S26MjVte8HhtwIYvtwj2BLrp0XO2vYHhSAqtguI3zjegmSDpX5Kt3TxMaEo0ZvBcA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@grpc/grpc-js": "^1.3.2",
     "@huddly/camera-proto": "1.0.11",
     "@huddly/camera-switch-proto": "0.0.6",
-    "@huddly/sdk-interfaces": "^0.1.2",
+    "@huddly/sdk-interfaces": "^0.2.0",
     "chalk": "^4.1.2",
     "cpio-stream": "^1.4.3",
     "google-protobuf": "^3.17.3",

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -113,7 +113,7 @@ export default class Api implements IDeviceCommonApi {
   }
 
   async getProductInfo(): Promise<any> {
-    return this.sendAndReceiveMessagePack(
+    const prodInfo = await this.sendAndReceiveMessagePack(
       Buffer.from(''),
       {
         send: 'prodinfo/get_msgpack',
@@ -121,6 +121,10 @@ export default class Api implements IDeviceCommonApi {
       },
       1000
     );
+    if (!prodInfo) {
+      return Promise.reject('Product info data retreived is empty or undefined!');
+    }
+    return prodInfo;
   }
 
   async setProductInfo(newProdInfoData: any): Promise<void> {

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -19,8 +19,6 @@ import Logger from '@huddly/sdk-interfaces/lib/statics/Logger';
 export default class Api implements IDeviceCommonApi {
   transport: IUsbTransport;
   locksmith: Locksmith;
-  setProdInfoMsgPackSupport: boolean = true;
-  getErrorLogMsgPackSupport: boolean = true;
 
   constructor(transport: IUsbTransport, locksmith: Locksmith) {
     this.transport = transport;
@@ -114,223 +112,27 @@ export default class Api implements IDeviceCommonApi {
     }
   }
 
-  async fileTransfer(
-    data: Buffer,
-    subscribedMessages: Array<string>,
-    timeout: number = 60000
-  ): Promise<any> {
-    const clearListeners = () => {
-      subscribedMessages.forEach((msg) => {
-        this.transport.removeAllListeners(msg);
-        this.transport.setEventLoopReadSpeed();
-        Logger.debug('Clearing out all file transfer listeners', 'SDK API');
-      });
-    };
-
-    return new Promise((resolve, reject) => {
-      const timeoutTimer = setTimeout(() => {
-        clearListeners();
-        Logger.error(
-          `Timing out since file transfer did not resolve after ${timeout} ms`,
-          '',
-          'SDK API'
-        );
-        reject(new Error('Timeout'));
-      }, timeout);
-
-      Logger.debug('Setting up async_file_transfer/* listeners', 'SDK API');
-      if (subscribedMessages.indexOf('async_file_transfer/data') >= 0) {
-        this.transport.on('async_file_transfer/data', async (msgPacket) => {
-          this.transport.setEventLoopReadSpeed(1);
-          await this.transport.write('async_file_transfer/data_reply');
-          const bufferComposition = Buffer.concat([data, msgPacket.payload]);
-          data = bufferComposition;
-        });
-      }
-
-      if (subscribedMessages.indexOf('async_file_transfer/receive') >= 0) {
-        this.transport.on('async_file_transfer/receive', async (msgPacket) => {
-          this.transport.setEventLoopReadSpeed(1);
-          if (msgPacket.payload.length !== 4) {
-            clearListeners();
-            clearTimeout(timeoutTimer);
-            reject(new Error('Data length is not 4, unable to proceed!'));
-          } else {
-            const length = Api.decode(msgPacket.payload, 'int');
-            const slice = data.slice(0, length);
-            await this.transport.write('async_file_transfer/receive_reply', slice);
-            data = data.slice(length);
-          }
-        });
-      }
-
-      if (subscribedMessages.indexOf('async_file_transfer/done') >= 0) {
-        this.transport.on('async_file_transfer/done', async (buffer) => {
-          clearListeners();
-          clearTimeout(timeoutTimer);
-          resolve(data);
-        });
-      }
-
-      if (subscribedMessages.indexOf('async_file_transfer/timeout') >= 0) {
-        this.transport.on('async_file_transfer/timeout', async (buffer) => {
-          clearListeners();
-          clearTimeout(timeoutTimer);
-          Logger.debug(
-            'Received a async_file_transfer/timeout message from camera. Timing out!',
-            'SDK API'
-          );
-          reject(new Error('Timeout'));
-        });
-      }
-    });
-  }
-
-  async asyncFileTransfer(
-    command: any,
-    data: Buffer = Buffer.alloc(0),
-    timeout: number = 5000
-  ): Promise<any> {
-    const res = await this.locksmith.executeAsyncFunction(async () => {
-      const subscribeMsgs = [
-        'async_file_transfer/data',
-        'async_file_transfer/receive',
-        'async_file_transfer/done',
-        'async_file_transfer/timeout',
-      ];
-      const transferRes = await this.withSubscribe(subscribeMsgs, async () => {
-        return new Promise(async (resolve, reject) => {
-          this.fileTransfer(data, subscribeMsgs)
-            .then((result) => {
-              resolve(result);
-            })
-            .catch((reason) => reject(reason));
-          const status = await this.sendAndReceive(
-            command.send_data ? command.send_data : Buffer.alloc(0),
-            command,
-            timeout
-          );
-          if (!status || !status['payload']) {
-            throw Error(
-              `Failed to get status. Status: ${JSON.stringify(status)} ${command['send']}`
-            );
-          }
-        });
-      });
-      return transferRes;
-    });
-    return res;
-  }
-
-  async getProductInfoLegacy(): Promise<any> {
-    const command = {
-      send: 'prodinfo/get',
-      receive: 'prodinfo/get_status',
-    };
-    const res = await this.asyncFileTransfer(command);
-    const prodInfo = Api.decode(res, 'messagepack');
-    return prodInfo;
-  }
-
   async getProductInfo(): Promise<any> {
-    if (!this.setProdInfoMsgPackSupport) {
-      return this.getProductInfoLegacy();
-    }
-
-    try {
-      const info = await this.sendAndReceiveMessagePack(
-        Buffer.from(''),
-        {
-          send: 'prodinfo/get_msgpack',
-          receive: 'prodinfo/get_msgpack_reply',
-        },
-        1000
-      );
-      this.setProdInfoMsgPackSupport = true;
-      if (!info) {
-        this.setProdInfoMsgPackSupport = false;
-        return this.getProductInfoLegacy();
-      }
-      return info;
-    } catch (e) {
-      this.setProdInfoMsgPackSupport = false;
-      Logger.debug(
-        'Prodinfo MessagePack not supported on this device. Using legacy procedure!',
-        'SDK API'
-      );
-      return this.getProductInfoLegacy();
-    }
-  }
-
-  async setProductInfoLegacy(newProdInfoData: any): Promise<void> {
-    await this.locksmith.executeAsyncFunction(async () => {
-      const asyncFileTransferMessages = [
-        'async_file_transfer/data',
-        'async_file_transfer/receive',
-        'async_file_transfer/done',
-        'async_file_transfer/timeout',
-      ];
-      const data = Api.encode(newProdInfoData);
-      const length = Api.encode({ size: data.length });
-      const command = {
-        send: 'prodinfo/set',
-        send_data: length,
-        receive: 'prodinfo/set_done',
-      };
-      await this.transport.clear();
-      try {
-        await this.transport.subscribe(command.receive);
-        await this.withSubscribe(
-          asyncFileTransferMessages,
-          async () =>
-            new Promise(async (resolve, reject) => {
-              this.fileTransfer(data, asyncFileTransferMessages);
-              const res = await this.sendAndReceive(
-                command.send_data ? command.send_data : Buffer.alloc(0),
-                command
-              );
-              if (res && res.payload) {
-                const errorCode = Api.decode(res.payload, 'messagepack');
-                if (errorCode === 0) {
-                  resolve(true);
-                } else {
-                  reject(`Set Product Info command failed with error code ${errorCode}`);
-                }
-              } else {
-                reject('No response received from camera during Set Product Info command');
-              }
-            })
-        );
-      } finally {
-        await this.transport.unsubscribe(command.receive);
-      }
-    });
+    return this.sendAndReceiveMessagePack(
+      Buffer.from(''),
+      {
+        send: 'prodinfo/get_msgpack',
+        receive: 'prodinfo/get_msgpack_reply',
+      },
+      1000
+    );
   }
 
   async setProductInfo(newProdInfoData: any): Promise<void> {
-    if (!this.setProdInfoMsgPackSupport) {
-      return this.setProductInfoLegacy(newProdInfoData);
-    }
-
-    try {
-      await this.transport.clear();
-      await this.sendAndReceive(
-        Api.encode(newProdInfoData),
-        {
-          send: 'prodinfo/set_msgpack',
-          receive: 'prodinfo/set_msgpack_reply',
-        },
-        10000
-      );
-      return Promise.resolve();
-    } catch (e) {
-      this.setProdInfoMsgPackSupport = false;
-      Logger.debug(
-        'SetProdinfo MessagePack not supported on this device. Using legacy procedure!',
-        'SDK API'
-      );
-      return this.setProductInfoLegacy(newProdInfoData);
-    }
+    await this.transport.clear();
+    await this.sendAndReceive(
+      Api.encode(newProdInfoData),
+      {
+        send: 'prodinfo/set_msgpack',
+        receive: 'prodinfo/set_msgpack_reply',
+      },
+      10000
+    );
   }
 
   static encode(payload: any): Buffer {
@@ -392,41 +194,7 @@ export default class Api implements IDeviceCommonApi {
     return info;
   }
 
-  async getErrorLogLegacy(timeout: number): Promise<any> {
-    Logger.debug('Start retrieving the error log', 'SDK API');
-    const res = await this.locksmith.executeAsyncFunction(async () => {
-      Logger.debug('Clearing transport pipes', 'SDK API');
-      await this.transport.clear();
-      const subscribeMsgs = [
-        'async_file_transfer/data',
-        'async_file_transfer/done',
-        'async_file_transfer/timeout',
-      ];
-
-      const result = await this.withSubscribe(
-        subscribeMsgs,
-        async () => {
-          return new Promise((resolve, reject) => {
-            this.fileTransfer(Buffer.alloc(0), subscribeMsgs, timeout)
-              .then((result) => {
-                resolve(result.toString('ascii'));
-              })
-              .catch((reason) => reject(reason));
-            Logger.debug('Sending "error_logger/read" message', 'SDK API');
-            this.transport.write('error_logger/read');
-          });
-        },
-        true
-      );
-      return result;
-    });
-    return res;
-  }
-
   async getErrorLog(timeout: number, retry: number = 1, allowLegacy: boolean = true): Promise<any> {
-    if (!this.getErrorLogMsgPackSupport && allowLegacy) {
-      return this.getErrorLogLegacy(timeout);
-    }
     try {
       const result = await this.sendAndReceiveMessagePack(
         Buffer.from(''),
@@ -436,7 +204,6 @@ export default class Api implements IDeviceCommonApi {
         },
         1000
       );
-      this.getErrorLogMsgPackSupport = true;
       if (result.error !== 0) {
         const msg = `Camera returned error on reading error log: ${result.error} ${result.string}`;
         Logger.warn(msg, 'SDK API');
@@ -447,13 +214,6 @@ export default class Api implements IDeviceCommonApi {
       if (retry > 0) {
         Logger.debug('Retrying getErrorLog', 'SDK API');
         return this.getErrorLog(timeout, retry - 1, allowLegacy);
-      } else if (allowLegacy) {
-        this.getErrorLogMsgPackSupport = false;
-        Logger.debug(
-          'ErrorLog MessagePack not supported on this device. Using legacy procedure!',
-          'SDK API'
-        );
-        return this.getErrorLogLegacy(timeout);
       } else {
         throw e;
       }

--- a/src/components/upgrader/boxfishUpgrader.ts
+++ b/src/components/upgrader/boxfishUpgrader.ts
@@ -163,47 +163,12 @@ export default class BoxfishUpgrader extends EventEmitter implements IDeviceUpgr
     return this.sendReceive('upgrader/allocate', { args: { size } });
   }
 
-  async legacyWriteBuf(buf: Buffer, offset: number = 0): Promise<any> {
-    Logger.debug('Falling back to legacy async file transfer', 'Boxfish PKG Upgrader');
-    const sendData = {
-      size: buf.length,
-      offset,
-    };
-    const command = {
-      send: 'upgrader/write',
-      send_data: Api.encode(sendData),
-      receive: 'upgrader/write_reply',
-    };
-    return this._cameraManager.api.asyncFileTransfer(command, buf);
-  }
-
-  async writeBuffProbe(): Promise<boolean> {
-    try {
-      await this.sendReceive('upgrader/write_buf', {
-        args: { data: Buffer.alloc(1), offset: 0 },
-        receiveEncoding: 'string',
-      });
-      return true;
-    } catch (e) {
-      Logger.error('Signle Write Buffer not supported in this firmware', e, 'Boxfish PKG Upgrader');
-      return false;
-    }
-  }
-
   async writeBuf(buf: Buffer, offset: number = 0): Promise<any> {
-    if (this.writeBufSupport === undefined) {
-      this.writeBufSupport = await this.writeBuffProbe();
-    }
-
-    if (this.writeBufSupport) {
-      const result = await this.sendReceive('upgrader/write_buf', {
-        args: { data: buf, offset },
-        receiveEncoding: 'messagepack',
-        timeout: 60000,
-      });
-      return result;
-    }
-    return this.legacyWriteBuf(buf, offset);
+    return this.sendReceive('upgrader/write_buf', {
+      args: { data: buf, offset },
+      receiveEncoding: 'messagepack',
+      timeout: 60000,
+    });
   }
 
   async sendReceive(cmd: string, options: any = {}): Promise<any> {

--- a/tests/components/device/factory.spec.ts
+++ b/tests/components/device/factory.spec.ts
@@ -15,6 +15,7 @@ import Dwarffish from './../../../src/components/device/dwarffish';
 import Clownfish from './../../../src/components/device/clownfish';
 import DartFish from './../../../src/components/device/dartfish';
 import Ace from './../../../src/components/device/ace';
+import HuddlyHex from '@huddly/sdk-interfaces/lib/enums/HuddlyHex';
 
 chai.should();
 chai.use(sinonChai);
@@ -248,7 +249,7 @@ describe('DeviceFactory', () => {
       it('should initialize Ace/L1 device when product id is 0x3E9', async () => {
         const dummyAceDevice = {
           deviceDescriptor: {
-            idProduct: 0x3E9
+            idProduct: HuddlyHex.L1_PID
           }
         };
         const deviceManager = await DeviceFactory.getDevice(


### PR DESCRIPTION
This PR removes all the async file transfer code that was used way back for upgrading and fetching error log. I.e. all the legacy methods that used asyncFileTransfer are deleted. 