### PR TITLE
fix: bufferStream now correctly implements destroy method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,7 +2197,20 @@
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -8141,6 +8154,14 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/src/utilitis/bufferStream.ts
+++ b/src/utilitis/bufferStream.ts
@@ -49,8 +49,10 @@ export default class BufferStream extends Readable {
   /**
    * Clean up variable references once the stream has been ended.
    */
-  destroy(): void {
+  destroy(): this {
     this.source = this.offset = this.length = undefined;
+    this.destroyed = true;
+    return this;
   }
 
   /**


### PR DESCRIPTION
Previous implementation had the wrong return type (according to the Readable interface).

I considered throwing an error if trying to call destroy on an instance that has already been destroyed, so I checked the behaviour of the stream provided by node:fs' createReadStream. It did not throw - so let's  keep it like this. 